### PR TITLE
docs: add per-domain READMEs and thin main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,30 +32,22 @@ The runner needs a tsx runner for `.ts` files:
 
 ## Repo Structure
 
-```text
-jobs/                 Runner job manifests (one JSON file per domain)
-src/
-  lib/                Shared infrastructure
-    constants.ts      THE file to edit on day one — all instance-specific values
-    pipeline-config.ts  Zod-validated operational config loader
-    silo-router.ts    Multi-tenant data routing by email domain / GitHub org / Slack workspace
-    dates.ts          Date formatting utilities (thin date-fns wrappers)
-    email.ts          Gmail parsing utilities (headers, body, attachments)
-    gh.ts             GitHub CLI wrappers (typed gh binary invocation)
-    gog.ts            Google Workspace CLI wrapper (gog binary with retry)
-    gateway-client.ts Gateway HTTP client for invoking OpenClaw tools
-    spawn-worker.ts   Gateway session spawner (dispatch pattern)
-  admin/              Token metrics, session refresh, maintenance
-  calendar/           Google Calendar event polling
-  convert/            DOCX/PDF → Markdown conversion
-  dispatchers/        LLM session dispatch framework (task-file-dispatcher.ts)
-  email/              Gmail polling, download, triage, classification
-  github/             Repo sync, issue sync, notifications, collaborator management
-  meetings/           Meeting extraction (Google Meet, Fathom, Notion) — entity pipeline exemplar
-  meta/               Entity lifecycle maintenance (sweep duplicates, disable old meta)
-  slack/              Slack message polling
-  x/                  X/Twitter: poll posts/mentions/feed/likes/bookmarks, post, like, repost (auto-refresh on 401)
-```
+Runner job manifests live in `jobs/` (one JSON file per domain). Scripts are organized by domain under `src/`:
+
+| Domain | Description | README |
+|--------|-------------|--------|
+| `admin/` | Token metrics, session refresh, maintenance | [README](src/admin/README.md) |
+| `calendar/` | Google Calendar event polling | [README](src/calendar/README.md) |
+| `convert/` | DOCX/PDF → Markdown conversion | [README](src/convert/README.md) |
+| `core/` | Housekeeping (orphaned file cleanup) | [README](src/core/README.md) |
+| `dispatchers/` | LLM session dispatch framework | [README](src/dispatchers/README.md) |
+| `email/` | Gmail polling, download, triage, classification | [README](src/email/README.md) |
+| `github/` | Repo sync, issue sync, notifications, collaborator management | [README](src/github/README.md) |
+| `lib/` | Shared infrastructure (constants, dates, email parsing, CLI wrappers) | [README](src/lib/README.md) |
+| `meetings/` | Meeting extraction (Google Meet, Fathom, Notion) | [README](src/meetings/README.md) |
+| `meta/` | Entity lifecycle maintenance | [README](src/meta/README.md) |
+| `slack/` | Slack message polling | [README](src/slack/README.md) |
+| `x/` | X/Twitter: polling, posting, engagement | [README](src/x/README.md) |
 
 Instance-specific directories (`vc/`, `tp/`) are not part of the template.
 

--- a/src/admin/README.md
+++ b/src/admin/README.md
@@ -1,0 +1,52 @@
+# admin/
+
+Token metrics collection, session cost management, and OpenClaw post-install patches.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `collect-token-metrics.ts` | Scans OpenClaw session transcripts and Claude Code session logs, writes immutable hourly rollup buckets to disk |
+| `session-refresh.ts` | Rotates bloated gateway sessions by resetting idle sessions with high cacheRead values |
+| `token-metrics.ts` | Queries pre-rolled hourly buckets and aggregates into a cost report for a given time range (also a CLI: `tsx src/admin/token-metrics.ts [--from ISO] [--to ISO]`) |
+| `refresh-token-rates.ts` | Dispatches an LLM session to fetch current published API pricing and update the rate card config |
+| `patch-openclaw.ts` | Orchestrator that runs all OpenClaw post-install patches in sequence |
+| `patch-tool-order.ts` | Patches OpenClaw's toolOrder array to insert Jeeves component tools above grep |
+| `patch-spawn-description.ts` | Patches OpenClaw's describeSessionsSpawnTool to prepend a Claude Code gate instruction |
+
+## Data Flow
+
+```
+collect-token-metrics  →  hourly bucket JSON files  →  token-metrics (query/aggregate)
+                                                    ←  refresh-token-rates (rate card)
+
+session-refresh  →  gateway API (refresh idle/oversized sessions)
+
+patch-openclaw  →  patch-tool-order + patch-spawn-description (post npm install -g openclaw)
+```
+
+- **collect-token-metrics** incrementally scans JSONL transcripts (OpenClaw + Claude Code), rolls usage into per-hour bucket files partitioned by channel and model.
+- **token-metrics** reads those buckets and the rate card to produce aggregated cost reports.
+- **session-refresh** polls active sessions and refreshes any that exceed the cacheRead threshold after being idle long enough.
+
+## Prerequisites
+
+No external prerequisites — all jobs run against local filesystem and gateway API.
+
+| Job | Schedule |
+|-----|----------|
+| `collect-token-metrics` | Every 97 min |
+| `session-refresh` | Every 23 min |
+| `refresh-token-rates` | Every 59 min |
+| `patch-tool-order` | Every 29 min |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/bucket-io.ts` | Hourly bucket file I/O — read, write, merge, flush |
+| `lib/channel-mapper.ts` | Maps session transcripts to channel keys (Slack, DM, heartbeat, subagent, meta-synthesis) |
+| `lib/claude-code-scanner.ts` | Scans Claude Code session JSONL files for Anthropic usage records |
+| `lib/rate-card.ts` | Token rate card loader and cost calculator ($/MTok) |
+| `lib/resolve-openclaw-dist.ts` | Resolves global npm openclaw dist directory for patching |
+| `types/token-metrics.ts` | Shared types across collector and query layers |

--- a/src/calendar/README.md
+++ b/src/calendar/README.md
@@ -1,0 +1,39 @@
+# calendar/
+
+Polls Google Calendar events for configured accounts and writes individual JSON files with SHA-256 hash-based change detection.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `poll.ts` | Iterates accounts from pipeline-config, fetches events via Calendar API, writes JSON files to silo-routed directories with change detection |
+
+## Data Flow
+
+```
+pipeline-config (accounts)  →  poll.ts  →  Google Calendar API  →  per-event JSON files
+                                           (via gog OAuth)          (silo-routed by email domain)
+```
+
+- Polls a 90-day lookback + 90-day forward window per account.
+- Uses SHA-256 hashing of significant event fields to detect changes; skips unchanged events.
+- Writes events under `{silo}/calendar/{calendarId}/` with sanitized filenames.
+- Tracks last-poll timestamps via runner state (`STATE_NAMESPACE = 'calendar'`).
+
+## Prerequisites
+
+- Google Calendar OAuth configured via `gog` CLI
+- Calendar accounts listed in `pipeline-config.json`
+- `GOG_CLIENT_PATH` and `GOG_CONFIG_DIR` set in `constants.ts`
+
+| Job | Schedule |
+|-----|----------|
+| `calendar-poll` | Every 17 min |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/calendar-api.ts` | Google Calendar REST API helpers — `listCalendars()` and `getAllEvents()` with pagination |
+| `../lib/pipeline-config.ts` | Provides `getCalendarAccounts()` |
+| `../lib/silo-router.ts` | Provides `getBasePathForEmailDomain()` for output routing |

--- a/src/convert/README.md
+++ b/src/convert/README.md
@@ -1,0 +1,32 @@
+# convert/
+
+CLI tools for converting DOCX and PDF files to Markdown with YAML frontmatter.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `docx-to-md.ts` | Converts `.docx` files to Markdown via mammoth HTML extraction. CLI: `tsx src/convert/docx-to-md.ts --paths=dir1,dir2` |
+| `pdf-to-md.ts` | Converts `.pdf` files to Markdown via pdf-parse text extraction. CLI: `tsx src/convert/pdf-to-md.ts --paths=dir1,dir2` |
+
+## Data Flow
+
+```
+--paths dirs  →  findFiles(ext)  →  needsConversion?  →  extract content  →  .docx.md / .pdf.md
+                                     (skip if up-to-date)   (mammoth/pdf-parse)   (with YAML frontmatter)
+```
+
+- Both scripts accept `--paths` with comma-separated directories to scan recursively.
+- Output files are written alongside the source (e.g., `report.docx` → `report.docx.md`).
+- Staleness checking: skips files whose `.md` output is newer than the source.
+- No runner job manifests — these are invoked on-demand via CLI.
+
+## Prerequisites
+
+No external prerequisites. Uses bundled npm dependencies (`mammoth`, `pdf-parse`).
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/convert-utils.ts` | Shared utilities — `findFiles()`, `needsConversion()`, `writeMdFile()` |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,27 @@
+# core/
+
+Housekeeping scripts for filesystem maintenance.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `sweep-orphaned-tmp.ts` | Removes orphaned `.tmp` files left behind by crashed atomic-write operations. Scans `CONTENT_DIR` and `SCRIPTS_DIR` for `.tmp` files older than 1 hour. |
+
+## Data Flow
+
+```
+CONTENT_DIR + SCRIPTS_DIR  →  recursive scan  →  delete .tmp files older than MAX_AGE_MS (1 hour)
+```
+
+- Skips `node_modules/` and `.git/` directories.
+- Silently skips non-existent directories.
+- Reports the count of removed files.
+
+## Prerequisites
+
+No external prerequisites. Requires `CONTENT_DIR` and `SCRIPTS_DIR` in `constants.ts`.
+
+| Job | Schedule |
+|-----|----------|
+| `sweep-orphaned-tmp` | Every 59 min |

--- a/src/dispatchers/README.md
+++ b/src/dispatchers/README.md
@@ -1,0 +1,88 @@
+# dispatchers/
+
+Framework for autonomous LLM task dispatchers that read Markdown task files and spawn gateway sessions to execute them. This is the mechanism behind daily briefings, social media content generation, and other standing-order operations.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `daily-digest.ts` | Reads `{CONTENT_DIR}/digest/TASK.md` and dispatches a gateway session to generate and publish a daily digest. Injects authoritative date context. |
+| `social-posts.ts` | Dynamically builds a task from pipeline-config refs and content paths, then dispatches a session to generate social media posts to a Notion database. |
+
+## Task-File-Dispatcher Framework
+
+The core framework lives in `lib/task-file-dispatcher.ts`. It provides a generic pattern:
+
+1. Read a task definition from a Markdown file (or build one dynamically)
+2. Optionally inject date/timezone context as a quoted block
+3. Wrap execution in `runScript()` for error handling
+4. Delegate to `runDispatcher()` from jeeves-runner with `SPAWN_WORKER_PATH`
+
+### Usage
+
+```typescript
+import { taskFileDispatcher } from './lib/task-file-dispatcher.js';
+
+taskFileDispatcher({
+  taskFile: path.join(CONTENT_DIR, 'my-domain/TASK.md'),
+  scriptName: 'dispatchers/my-dispatcher',
+  jobId: 'my-dispatcher-job',
+  thinking: 'low',
+  timeout: 600,
+  injectDateContext: true,
+});
+```
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `taskFile` | `string` | Path to the task Markdown file |
+| `scriptName` | `string` | Script name for `runScript()` crash handler |
+| `jobId` | `string` | Runner job ID for `runDispatcher()` |
+| `thinking` | `string` | Thinking budget level (e.g., `'low'`) |
+| `timeout` | `number` | Session timeout in seconds |
+| `injectDateContext` | `boolean` | Prepend authoritative date/day-of-week context |
+| `dateTimezone` | `string` | IANA timezone for date injection (default: `'Asia/Makassar'`) |
+
+## TASK File Anatomy
+
+A TASK file is a Markdown document containing standing orders for an LLM session. It defines:
+
+- **What to do** — the goal of the session (generate a digest, write social posts, etc.)
+- **Data sources** — which files/directories/APIs to read
+- **Output destinations** — where to write results (Notion, Slack, filesystem)
+- **Rules and constraints** — content guidelines, formatting requirements, routing instructions
+
+Example location: `{CONTENT_DIR}/digest/TASK.md`
+
+When `injectDateContext: true`, the framework prepends:
+
+```
+> **Today is Monday, 2025-05-19 (Asia/Makassar).** Use this as the authoritative date reference...
+```
+
+## Standing Orders Convention
+
+Dispatchers implement a "standing orders" pattern:
+
+- **Static tasks** (daily-digest): Read a fixed TASK.md file that rarely changes. The LLM session follows the standing orders each run.
+- **Dynamic tasks** (social-posts): Build the task string at runtime from configuration refs, content paths, and business rules. The `buildTask()` function constructs the full instruction set.
+
+Both patterns ultimately call `runDispatcher()` which spawns a gateway worker session to execute the task autonomously.
+
+## Prerequisites
+
+- Gateway API accessible (`GATEWAY_HOST`, `GATEWAY_PORT`)
+- `SPAWN_WORKER_PATH` pointing to `spawn-worker.ts`
+- TASK.md files present in expected content directories
+- For social-posts: Notion database ID and Slack channels configured in pipeline-config refs
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/task-file-dispatcher.ts` | Core framework — reads task file, injects date context, delegates to `runDispatcher()` |
+| `../lib/constants.ts` | Provides `CONTENT_DIR`, `SPAWN_WORKER_PATH` |
+| `../lib/pipeline-config.ts` | Provides `getRef()` for external service IDs |
+| `../lib/spawn-worker.ts` | Gateway session spawner invoked by `runDispatcher()` |

--- a/src/email/README.md
+++ b/src/email/README.md
@@ -1,0 +1,70 @@
+# email/
+
+Gmail polling, download, triage, and classification pipeline. Polls configured accounts for new threads, classifies them into buckets, downloads message bodies, and applies Gmail labels.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `poll.ts` | Polls Gmail accounts for new/updated threads, classifies them (receipt, junk, bucket), and enqueues for download |
+| `download.ts` | Dequeues threads from `email-pending` and downloads full message bodies, headers, and attachments |
+| `drain-updates.ts` | Dequeues label-change actions from `email-updates` and applies them to Gmail via `gog gmail thread modify` |
+| `backfill-bodies.ts` | One-shot: finds cached threads missing downloaded message bodies and enqueues them |
+| `backfill-classification.ts` | One-shot: classifies threads missing receipt/junk/bucket fields and enqueues label actions |
+| `backfill-historical.ts` | One-shot: searches Gmail for threads in a date range predating the pipeline and processes them |
+| `backfill-labels.ts` | One-shot: enqueues label actions for threads with classification but no applied labels |
+| `inventory.ts` | Prints a summary table of thread directories, message files, and state counts per account |
+
+## Data Flow
+
+```
+poll  →  classify (receipt/junk/bucket)  →  enqueue email-pending + email-updates
+                                                    ↓                    ↓
+                                              download             drain-updates
+                                           (fetch bodies)       (apply Gmail labels)
+                                                    ↓
+                                          per-message JSON files
+                                          (silo-routed by account)
+```
+
+1. **poll** searches Gmail via `gog gmail search`, classifies each thread, enqueues important threads to `email-pending` for body download and label actions to `email-updates`.
+2. **download** dequeues from `email-pending` (up to 50/run), fetches full messages via `gog gmail get`, extracts headers/body/attachments, and writes per-message JSON files.
+3. **drain-updates** dequeues from `email-updates` (up to 100/run), pre-creates missing Gmail labels, applies label changes with rate limiting (60 calls/min).
+
+### Classification
+
+- **Receipt candidate**: matches financial receipt/invoice keywords in subject/snippet/from
+- **Junk candidate**: matches newsletter/promo/marketing keywords
+- **Bucket**: domain-based classification via pipeline-config (e.g., VC, Sales, Personal)
+- Labels are computed by `computeLabelsToApply()` and applied idempotently
+
+### State Management
+
+- Per-thread state stored in runner SQLite via `email-state.ts` (classification, seen timestamps, label application)
+- Per-account scalar state tracks last poll timestamp
+- Thread cache files (`thread.json`) store message metadata, labels, and provenance history
+
+## Prerequisites
+
+- Gmail OAuth configured via `gog` CLI
+- Email accounts listed in `pipeline-config.json` with `emailPolling: true`
+- `GOG_CLIENT_PATH` set in `constants.ts`
+
+| Job | Schedule |
+|-----|----------|
+| `email-poll` | Every 11 min |
+| `email-download` | Every 13 min |
+| `email-drain-updates` | Every 17 min |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `email-cache.ts` | Per-thread JSON cache — load, save, create/update, detect label changes |
+| `email-fetch.ts` | Fetch full thread metadata from Gmail, update cache/provenance, enqueue for download |
+| `email-state.ts` | Per-thread and per-account state in runner SQLite store |
+| `email-triage.ts` | Pure-function classification helpers (receipt, junk, bucket, importance) |
+| `../lib/email.ts` | Gmail payload parsing (headers, body decoding, attachment extraction) |
+| `../lib/gog.ts` | Google Workspace CLI wrapper with retry |
+| `../lib/pipeline-config.ts` | Account lists and domain-to-bucket routing |
+| `../lib/silo-router.ts` | Per-account filesystem path routing |

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -1,0 +1,56 @@
+# github/
+
+GitHub repo sync, issue sync, notification monitoring, and collaborator management.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `build-registry.ts` | Enumerates all accessible GitHub repos (with push access) and external org repos, builds a JSON registry with metadata and social policy classification |
+| `sync-repos.ts` | Shallow-clones or pulls tracked repos in round-robin batches (15 per run) via runner state_items |
+| `sync-issues.ts` | Fetches issues for tracked repos in round-robin batches (10 per run), stores as JSON with diff history via fast-json-patch |
+| `poll-collabs.ts` | Polls repos and pending invitations, enqueues items needing bot access to the `gh-collabs` queue |
+| `drain-collabs.ts` | Dequeues collaborator operations — adds bot as collaborator and accepts invitations |
+| `watch.ts` | Polls GitHub notifications for both primary account and bot user, detects important/stale items, enqueues escalations |
+
+## Data Flow
+
+```
+build-registry  →  GITHUB_REGISTRY_PATH (repos.json)
+                         ↓
+              sync-repos (clone/pull)  +  sync-issues (fetch issues)
+                    ↓                           ↓
+         silo-routed repo clones       per-issue JSON with patch history
+
+poll-collabs  →  gh-collabs queue  →  drain-collabs (add collaborator / accept invitation)
+
+watch  →  notification state  →  escalation queue (review requests, mentions, stale items)
+```
+
+- **build-registry** runs daily, enumerating repos via GitHub API and writing the registry file.
+- **sync-repos** and **sync-issues** read the registry and process repos in round-robin order, prioritizing least-recently-synced.
+- **sync-issues** maintains change history using JSON patches (up to 50 history entries per issue).
+- **poll-collabs** / **drain-collabs** manage bot access across repos, switching between primary account and bot user as needed.
+- **watch** tracks notification state per user and detects important reasons (review_requested, mention, etc.).
+
+## Prerequisites
+
+- GitHub CLI authenticated (`gh auth login`) for both `GH_ACCOUNT` and `GH_BOT_USER`
+- `GH_BIN`, `GH_CONFIG_DIR`, `GH_ACCOUNT`, `GH_BOT_USER` set in `constants.ts`
+
+| Job | Schedule |
+|-----|----------|
+| `github-build-registry` | Daily at 02:13 UTC |
+| `github-sync-repos` | Every 19 min |
+| `github-sync-issues` | Every 23 min |
+| `github-watch` | Every 29 min |
+| `github-poll-collabs` | Daily at 03:07 UTC |
+| `github-drain-collabs` | Every 31 min |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `../lib/gh.ts` | GitHub CLI wrappers — `gh()`, `ghJson()`, `ghApi()`, `setupGhConfig()` |
+| `../lib/silo-router.ts` | `getBasePathForGitHubOrg()` for org-based output routing |
+| `../lib/constants.ts` | GitHub-specific constants (accounts, paths, registry location) |

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,97 @@
+# lib/
+
+Shared infrastructure consumed by all domain scripts. This is where instance configuration, CLI wrappers, and cross-cutting utilities live.
+
+## Modules
+
+### constants.ts
+
+**The first file to edit on a new instance.** Centralized paths, credentials, and integration-specific values used across all scripts.
+
+Key exports:
+- Directory paths: `CONTENT_DIR`, `SCRIPTS_DIR`, `CREDENTIALS_DIR`, `SESSIONS_DIR`, etc.
+- GitHub: `GH_BIN`, `GH_CONFIG_DIR`, `GH_ACCOUNT`, `GH_BOT_USER`, `GITHUB_DIR`, `GITHUB_REGISTRY_PATH`
+- Google: `GOG_BIN`, `GOG_CONFIG_DIR`, `GOG_CLIENT_PATH`
+- Email: `EMAIL_EVENTS_DIR`
+- Slack: `PRIMARY_WORKSPACE`, `SLACK_DOMAIN_DIR`, `SLACK_WORKSPACE_CACHE_PATH`
+- X/Twitter: `X_OAUTH_DIR`, `X_ACCOUNTS`
+- Meetings: `DEFAULT_MEETINGS_DIR`
+- Gateway: `GATEWAY_HOST`, `GATEWAY_PORT`, `SPAWN_WORKER_PATH`
+- Token metrics: `TOKEN_METRICS_DIR`, `TOKEN_RATES_PATH`, `SESSION_REFRESH_*` thresholds
+- Entity types: `ENTITY_TYPES` array with `subdir`, `rejectionKeys`, `maxAgeDays` per type
+
+### dates.ts
+
+Thin wrappers around date-fns. No config dependencies.
+
+- `dayOfWeek(dateStr)` — full weekday name (e.g., "Monday"). Important because LLMs cannot do day-of-week arithmetic reliably.
+- `formatDate(dateStr, fmt)` — format a date using date-fns pattern
+- `relativeDays(dateStr, referenceStr?)` — human-friendly relative description ("3 days ago", "today")
+- Re-exports `format` and `parseISO` from date-fns
+
+### email.ts
+
+Gmail parsing utilities for raw Gmail API payloads. No config dependencies.
+
+- `headerValue(headers, name)` — extract header value (case-insensitive)
+- `extractTextFromPayload(payload)` — recursively extract text and HTML from MIME parts, decoding base64
+- `extractAttachments(payload)` — recursively extract attachment metadata (filename, mimeType, size, attachmentId)
+
+### gh.ts
+
+GitHub CLI wrappers with typed invocation. Depends on `GH_BIN`, `GH_CONFIG_DIR`.
+
+- `setupGhConfig()` — sets `GH_CONFIG_DIR` env var so `gh` finds correct auth tokens
+- `gh(args, options?)` — run `gh` CLI command, return structured `GhResult` (`ok`, `status`, `out`, `err`)
+- `ghJson(args)` — run `gh` and parse stdout as JSON
+- `ghApi(endpoint)` — call GitHub REST API via `gh api`
+
+### gog.ts
+
+Google Workspace CLI wrapper with retry. Depends on `GOG_BIN`, `CREDENTIALS_DIR`.
+
+- `gogWithRetry(args, opts?)` — run `gog` command with retry logic for transient network errors (context deadline exceeded, timeouts). Sets `APPDATA` to `CREDENTIALS_DIR` for Windows credential location.
+
+### gateway-client.ts
+
+Gateway HTTP client for OpenClaw tool invocation. Depends on `GATEWAY_HOST`, `GATEWAY_PORT`.
+
+- `loadGatewayToken()` — load bearer token from `~/.openclaw/openclaw.json` or `CLAWDBOT_GATEWAY_TOKEN` env var
+- `gatewayInvoke(tool, args, options?)` — invoke an OpenClaw gateway HTTP API tool
+- `unwrapResult(r)` — unwrap result from gateway response
+
+### pipeline-config.ts
+
+Zod-validated pipeline configuration loader. Depends on `PIPELINE_CONFIG_PATH`.
+
+- `loadPipelineConfig()` — load and cache config with Zod validation
+- `getRef(key)` — get a ref value by dotted key (e.g., `'notion.socialPostsDatabaseId'`)
+- `getCalendarAccounts()` — accounts with calendar config
+- `getEmailAccounts()` — email addresses with `emailPolling: true`
+- `getBucketForDomain(domain)` — match email domain to classification bucket
+- `getBucketPriority()` — bucket name to priority index mapping
+
+### silo-router.ts
+
+Multi-tenant data routing by email domain, GitHub org, and Slack workspace. Depends on `SILO_ROUTING_CONFIG_PATH`.
+
+- `getBasePathForEmailDomain(domain)` — resolve email domain to base content path
+- `getBasePathForGitHubOrg(org)` — resolve GitHub org to base path (with optional relative path)
+- `getBasePathForSlackWorkspace(teamId)` — resolve Slack workspace to base path
+- `getBasePathForMeeting(participantEmails)` — resolve meeting to base path via majority-voting on participant email domains
+- `getEntityDirs(subdir)` — deduplicated list of entity root directories across all silos
+- `getEmailBaseForAccount(account)` / `getCalendarBaseForAccount(account)` — per-account path helpers
+
+Single-tenant instances route everything to `CONTENT_DIR` by default.
+
+### spawn-worker.ts
+
+Gateway session spawner — executable script invoked by `runDispatcher()`.
+
+Usage: `echo "task" | tsx spawn-worker.ts --job-id=<id> [--label=<label>] [--thinking=<level>] [--timeout=<seconds>]`
+
+- Spawns a session via OpenClaw gateway HTTP API
+- Polls for completion (checks session history and staleness)
+- Waits for transcript to flush
+- Outputs `WORKER_RESULT:{"sessionKey":"...","tokens":12345,"durationMs":123000}` on last stdout line
+- Implements retry with exponential backoff (3 retries, 30s base)

--- a/src/meetings/README.md
+++ b/src/meetings/README.md
@@ -1,0 +1,74 @@
+# meetings/
+
+Meeting extraction from three independent sources — Google Meet (via email), Fathom recordings, and Notion inbox — writing to a shared entity store. This domain is the exemplar for the entity pipeline pattern.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `extract.ts` | Scans the email cache for meeting-related threads, detects source (Google Meet, Fathom), creates meeting packages with metadata and artifacts |
+| `fetch-notes.ts` | Walks meeting directories, fetches Gemini doc transcripts and Fathom transcripts for meetings that need them |
+| `ingest-notion.ts` | Polls a Notion inbox database, fetches meeting content via browser extraction, stages artifacts locally, archives the inbox page |
+| `migrate-alignment.ts` | One-shot: brings existing meeting packages into conformance with the canonical meeting-package contract |
+| `migrate-fathom.ts` | One-shot: remediates existing Fathom meetings — re-detects URLs, reclassifies, fetches missing transcripts |
+
+## Data Flow
+
+```
+Email cache  →  extract.ts  →  meeting packages ({silo}/meetings/{id}/)
+                                    ↓
+                              fetch-notes.ts  →  Gemini docs (gog export)
+                                              →  Fathom transcripts (puppeteer / share page)
+
+Notion inbox  →  ingest-notion.ts  →  meeting packages
+                  (browser extract)     (summary.txt, transcript.txt, meeting.json)
+```
+
+### Meeting Package Structure
+
+Each meeting lives in a directory under `{silo}/meetings/{meetingId}/`:
+
+- `meeting.json` — canonical metadata (Zod-validated via `meeting-schema.ts`)
+- `transcript.txt` — extracted transcript (from Gemini, Fathom, or Notion)
+- `summary.txt` — meeting summary (from Fathom or Notion)
+- `gemini_link.txt` — Google Meet Gemini doc URL
+- `fathom-*.html` — raw Fathom email HTML
+- Source email JSON files
+
+### Three Independent Extractors
+
+1. **Google Meet** (via email): Detects meeting invitations/summaries in email, extracts participants, creates packages, fetches Gemini doc transcripts via `gog`
+2. **Fathom** (via email + share pages): Detects Fathom recording URLs in email bodies, fetches transcripts from public share pages using puppeteer-core with headless Chrome
+3. **Notion** (via API + browser): Queries a Notion inbox database, extracts content (Summary/Notes/Transcript tabs) via gateway browser tool, archives processed pages
+
+## Prerequisites
+
+- Gmail OAuth via `gog` (email pipeline must be running for extract/fetch-notes)
+- For Notion ingestion: `NOTION_API_KEY_PATH` and inbox database ID in pipeline-config refs
+- Chrome installed (for Fathom share page extraction via puppeteer-core)
+
+| Job | Schedule |
+|-----|----------|
+| `meetings-extract` | Every 13 min |
+| `meetings-fetch-notes` | Every 19 min |
+| `meetings-ingest-notion` | Every 23 min (disabled by default) |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/meeting-schema.ts` | Canonical meeting.json Zod schema, `writeMeetingMeta()`, sort timestamp computation |
+| `lib/detect.ts` | Meeting detection — subject matching, title normalization, participant extraction, Fathom URL detection, meeting ID generation |
+| `lib/package.ts` | Creates/updates meeting package directories and artifacts, manages runner-state index |
+| `lib/meetings-dirs.ts` | Discovers all meetings directories across silos via `getEntityDirs()` |
+| `lib/doc-fetch.ts` | Fetches Google Doc transcripts via `gog` CLI for meetings with `gemini_link.txt` |
+| `lib/fathom-extract.ts` | Extracts transcripts from `fathom-*.html` files into `transcript.txt` |
+| `lib/fathom-share-fetch.ts` | Fetches summary/transcript from public Fathom share pages using puppeteer-core |
+| `lib/fathom-share-dom.ts` | Pure DOM extraction helpers for Fathom share page content |
+| `lib/fathom-share-ingest.ts` | Pipeline for Fathom share meetings needing transcript fetching |
+| `lib/notion-api.ts` | Notion API HTTP helpers with authentication |
+| `lib/notion-browser-extract.ts` | Extracts meeting content from Notion public pages via gateway browser tool |
+| `lib/notion-inbox-processor.ts` | Processes a Notion inbox page end-to-end: fetch, extract, stage, archive |
+| `lib/meeting-cursor.ts` | Cursor and sort logic for global meetings meta steering |
+| `lib/migration-args.ts` | Shared CLI argument parsing for migration scripts (`--live`, `--max`) |
+| `lib/migration-backup.ts` | Backup and reversibility utilities for migrations |

--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -1,0 +1,40 @@
+# meta/
+
+Entity lifecycle maintenance — sweeps duplicate entities and disables stale metadata entries.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `sweep-duplicates.ts` | Scans entity directories for rejections (deletes entity) and duplicates (merges files into original, then deletes duplicate). Uses copy + delete instead of move because watcher holds file locks. |
+| `disable-old-meta.ts` | Disables stale meta entries for time-bounded entity types. If an entity's date exceeds `maxAgeDays` and synthesis is complete (`_content` exists), writes `_disabled: true` to prevent further synthesis scheduling. |
+
+## Data Flow
+
+```
+ENTITY_TYPES (constants.ts)  →  getEntityDirs() (silo-router)  →  scan .meta/meta.json per entity
+                                                                         ↓
+                                                              sweep-duplicates: merge + delete
+                                                              disable-old-meta: write _disabled
+```
+
+- Both scripts loop over `ENTITY_TYPES` from constants, which defines `subdir`, `rejectionKeys`, and `maxAgeDays` per entity type.
+- Directory resolution uses `getEntityDirs()` from silo-router to find entity roots across all silos.
+- **sweep-duplicates** recognizes multiple case variants of `duplicateOf` keys and resolves values to absolute directory paths (bare hex IDs, full paths, or partial paths).
+- **disable-old-meta** extracts dates from meta fields or `_content` headers and compares against `maxAgeDays`.
+
+## Prerequisites
+
+No external prerequisites. Operates on local filesystem entity directories.
+
+| Job | Schedule |
+|-----|----------|
+| `meta-sweep-duplicates` | Every 29 min |
+| `meta-disable-old` | Daily at 04:11 UTC |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `../lib/constants.ts` | `ENTITY_TYPES` array defining entity type config |
+| `../lib/silo-router.ts` | `getEntityDirs()` for cross-silo directory discovery |

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -1,0 +1,43 @@
+# slack/
+
+Polls Slack channels for new messages across configured workspaces, auto-discovers channels the bot has joined, and writes per-message JSON archives.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `poll.ts` | Auto-discovers channels, fetches history and thread replies via Slack API, writes individual JSON files per message to silo-routed directories. Supports multi-account/multi-workspace scenarios. |
+
+## Data Flow
+
+```
+Bot tokens  →  auto-discover channels  →  fetch history + thread replies  →  per-message JSON files
+(env/config)    (public, private,           (paginated, since last poll)      (silo-routed by workspace)
+                 IM, MPIM)
+```
+
+- Loads Slack bot tokens from environment or `.openclaw/openclaw.json` / `.clawdbot/clawdbot.json` config files.
+- Auto-discovers all channel types the bot is a member of (public, private, IM, MPIM), excluding archived.
+- Fetches paginated conversation history since last poll timestamp per channel.
+- Fetches thread replies for threaded messages.
+- Writes one JSON file per message under `{silo}/slack/{channelName}/`.
+- Handles channel renames by detecting and renaming the output directory.
+- Resolves workspace routing via `getBasePathForSlackWorkspace()` for multi-workspace setups.
+- Loads user ID → username mappings from `users.json` for message enrichment.
+
+## Prerequisites
+
+- Slack bot token configured (via environment variable or config file)
+- `PRIMARY_WORKSPACE`, `SLACK_DOMAIN_DIR`, `SLACK_WORKSPACE_CACHE_PATH` set in `constants.ts`
+
+| Job | Schedule |
+|-----|----------|
+| `slack-poll` | Every 11 min |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/slack-api.ts` | Typed Slack Web API wrappers — `fetchHistory()`, `fetchReplies()`, `discoverChannels()`, `slackApi()` with pagination |
+| `../lib/constants.ts` | Workspace routing constants |
+| `../lib/silo-router.ts` | `getBasePathForSlackWorkspace()` for output directory routing |

--- a/src/x/README.md
+++ b/src/x/README.md
@@ -1,0 +1,45 @@
+# X (Twitter) Domain
+
+Polls, posts, and engages on X/Twitter via API v2. Supports multiple accounts with OAuth 2.0 PKCE.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `poll-posts.ts` | Poll an account's own posts via X API v2 (Owned Read) |
+| `poll-mentions.ts` | Poll mentions for an account |
+| `poll-feed.ts` | Poll the home timeline — writes directly to feed/ directory |
+| `poll-likes.ts` | Poll liked tweets for an account |
+| `poll-bookmarks.ts` | Poll bookmarks for an account |
+| `drain-queues.ts` | Drain all X runner queues to disk as JSON files |
+| `post.ts` | Dispatch queued posts, replies, and quotes |
+| `like.ts` | Process the like queue |
+| `repost.ts` | Process the repost queue |
+| `refresh-token.ts` | Refresh OAuth 2.0 access token (manual or scheduled) |
+
+## Data Flow
+
+```
+poll-posts/mentions/feed/likes/bookmarks
+  → enqueue to runner queues (x-{type}-{handle})
+  → drain-queues writes JSON to disk
+
+post/like/repost
+  → dequeue from runner queues
+  → call X API v2 endpoints
+  → auto-refresh token on 401
+```
+
+`poll-feed` is the exception — it writes feed items directly to the account's `feed/` directory instead of using the queue pattern.
+
+## Prerequisites
+
+- X API credentials: `X_CLIENT_ID` and `X_CLIENT_SECRET` in `constants.ts`
+- OAuth 2.0 PKCE tokens per account (generated via initial auth flow, refreshed by `refresh-token.ts`)
+- Account handles configured in `X_ACCOUNTS` in `constants.ts`
+
+## Key Dependencies
+
+- `src/x/lib/` — X API client wrappers, OAuth token management, polling helpers
+- `src/lib/constants.ts` — `X_ACCOUNTS`, `X_CLIENT_ID`, `X_CLIENT_SECRET`
+- `src/lib/pipeline-config.ts` — additional X config references


### PR DESCRIPTION
Restructure the README into a thin index pointing to per-domain READMEs. Each domain directory now has its own comprehensive README covering scripts, data flow, prerequisites, and key dependencies. The main README becomes a summary table with links.