### PR TITLE
fix: resolve-openclaw-dist nvm fallback

### DIFF
--- a/src/admin/lib/resolve-openclaw-dist.test.ts
+++ b/src/admin/lib/resolve-openclaw-dist.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for resolve-openclaw-dist nvm fallback logic.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process');
+vi.mock('node:fs');
+vi.mock('node:os');
+
+const mockedExecSync = vi.mocked(execSync);
+const mockedFs = vi.mocked(fs);
+const mockedOs = vi.mocked(os);
+
+describe('resolveOpenClawDist', () => {
+  // Dynamic import to pick up fresh mocks each test
+  const loadModule = async () => {
+    vi.resetModules();
+    return import('./resolve-openclaw-dist.js');
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedOs.homedir.mockReturnValue('/home/jeeves');
+  });
+
+  afterEach(() => {
+    delete process.env.NVM_DIR;
+  });
+
+  it('returns npm root -g path when npm is available', async () => {
+    mockedExecSync.mockReturnValue(
+      '/home/jeeves/.nvm/versions/node/v24.16.0/lib/node_modules\n',
+    );
+    mockedFs.existsSync.mockReturnValue(true);
+
+    const { resolveOpenClawDist } = await loadModule();
+    const result = resolveOpenClawDist();
+
+    expect(result).toBe(
+      path.join(
+        '/home/jeeves/.nvm/versions/node/v24.16.0/lib/node_modules',
+        'openclaw',
+        'dist',
+      ),
+    );
+  });
+
+  it('falls back to nvm current symlink when npm fails', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('npm: command not found');
+    });
+
+    const nvmDir = '/home/jeeves/.nvm';
+    const versionsNode = path.join(nvmDir, 'versions', 'node');
+    const currentLink = path.join(nvmDir, 'current');
+    const currentDist = path.join(
+      currentLink,
+      'lib',
+      'node_modules',
+      'openclaw',
+      'dist',
+    );
+
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s === versionsNode) return true;
+      if (s === currentLink) return true;
+      if (s === currentDist) return true;
+      return false;
+    });
+
+    process.env.NVM_DIR = nvmDir;
+
+    const { resolveOpenClawDist } = await loadModule();
+    const result = resolveOpenClawDist();
+
+    expect(result).toBe(currentDist);
+  });
+
+  it('falls back to scanning nvm version directories', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('npm: command not found');
+    });
+
+    const targetVersion = 'v24.16.0';
+    const expectedDist = path.join(
+      '/home/jeeves/.nvm',
+      'versions',
+      'node',
+      targetVersion,
+      'lib',
+      'node_modules',
+      'openclaw',
+      'dist',
+    );
+
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith(path.join('versions', 'node'))) return true;
+      if (s.endsWith('current')) return false; // no current symlink
+      if (s === expectedDist) return true;
+      return false;
+    });
+
+    (
+      mockedFs.readdirSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue(['v22.0.0', targetVersion]);
+
+    process.env.NVM_DIR = '/home/jeeves/.nvm';
+
+    const { resolveOpenClawDist } = await loadModule();
+    const result = resolveOpenClawDist();
+
+    expect(result).toBe(expectedDist);
+  });
+
+  it('prefers newest nvm version', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('npm: command not found');
+    });
+
+    const newerDist = path.join(
+      '/home/jeeves/.nvm',
+      'versions',
+      'node',
+      'v24.16.0',
+      'lib',
+      'node_modules',
+      'openclaw',
+      'dist',
+    );
+
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith(path.join('versions', 'node'))) return true;
+      if (s.endsWith('current')) return false;
+      if (s === newerDist) return true;
+      // v22 also has it, but v24 should win (sorted reverse)
+      if (s.includes('v22.0.0') && s.includes('openclaw/dist')) return true;
+      return false;
+    });
+
+    (
+      mockedFs.readdirSync as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue(['v22.0.0', 'v24.16.0']);
+
+    process.env.NVM_DIR = '/home/jeeves/.nvm';
+
+    const { resolveOpenClawDist } = await loadModule();
+    const result = resolveOpenClawDist();
+
+    expect(result).toBe(newerDist);
+  });
+
+  it('throws descriptive error when all methods fail', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('npm: command not found');
+    });
+
+    mockedFs.existsSync.mockReturnValue(false);
+
+    process.env.NVM_DIR = '/home/jeeves/.nvm';
+
+    const { resolveOpenClawDist } = await loadModule();
+
+    expect(() => resolveOpenClawDist()).toThrow(
+      'OpenClaw dist directory not found',
+    );
+    expect(() => resolveOpenClawDist()).toThrow('npm root -g');
+    expect(() => resolveOpenClawDist()).toThrow('NVM_DIR');
+  });
+
+  it('uses ~/.nvm when NVM_DIR is not set', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('npm: command not found');
+    });
+
+    // No NVM_DIR set, should use os.homedir() + .nvm
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const { resolveOpenClawDist } = await loadModule();
+
+    expect(() => resolveOpenClawDist()).toThrow(
+      'OpenClaw dist directory not found',
+    );
+    // Verify it tried the homedir-based path
+    expect(mockedFs.existsSync).toHaveBeenCalledWith(
+      path.join('/home/jeeves', '.nvm', 'versions', 'node'),
+    );
+  });
+});

--- a/src/admin/lib/resolve-openclaw-dist.ts
+++ b/src/admin/lib/resolve-openclaw-dist.ts
@@ -6,20 +6,90 @@
  *
  * Used after `npm install -g openclaw` to apply runtime patches to the
  * installed openclaw distribution (e.g. fixing gateway spawn behavior).
- * Throws if openclaw is not installed globally.
+ *
+ * Falls back to scanning nvm directories when `npm root -g` is not
+ * available (e.g. non-interactive shells on managed instances where
+ * nvm is only loaded in interactive .bashrc).
  */
 
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+
+/**
+ * Try resolving via `npm root -g`. Returns the dist path or null.
+ */
+function tryNpmRoot(): string | null {
+  try {
+    const npmRoot = execSync('npm root -g', {
+      encoding: 'utf8',
+      timeout: 10_000,
+    }).trim();
+    const distDir = path.join(npmRoot, 'openclaw', 'dist');
+    if (fs.existsSync(distDir)) return distDir;
+  } catch {
+    // npm not on PATH — fall through to nvm fallback
+  }
+  return null;
+}
+
+/**
+ * Scan nvm node version directories for an openclaw global install.
+ * Checks NVM_DIR env var, then falls back to ~/.nvm.
+ */
+function tryNvmFallback(): string | null {
+  const nvmDir = process.env.NVM_DIR ?? path.join(os.homedir(), '.nvm');
+  const versionsDir = path.join(nvmDir, 'versions', 'node');
+
+  if (!fs.existsSync(versionsDir)) return null;
+
+  // Check 'current' symlink first (created by jeeves-tools bootstrap)
+  const currentLink = path.join(nvmDir, 'current');
+  if (fs.existsSync(currentLink)) {
+    const distDir = path.join(
+      currentLink,
+      'lib',
+      'node_modules',
+      'openclaw',
+      'dist',
+    );
+    if (fs.existsSync(distDir)) return distDir;
+  }
+
+  // Scan version directories (newest first by sort order)
+  const versions = fs
+    .readdirSync(versionsDir)
+    .filter((d) => d.startsWith('v'))
+    .sort()
+    .reverse();
+
+  for (const version of versions) {
+    const distDir = path.join(
+      versionsDir,
+      version,
+      'lib',
+      'node_modules',
+      'openclaw',
+      'dist',
+    );
+    if (fs.existsSync(distDir)) return distDir;
+  }
+
+  return null;
+}
 
 /** Resolve the global npm openclaw dist directory. */
 export function resolveOpenClawDist(): string {
-  const npmRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
-  const distDir = path.join(npmRoot, 'openclaw', 'dist');
+  const distDir = tryNpmRoot() ?? tryNvmFallback();
 
-  if (!fs.existsSync(distDir)) {
-    throw new Error(`OpenClaw dist directory not found: ${distDir}`);
+  if (!distDir) {
+    throw new Error(
+      'OpenClaw dist directory not found. ' +
+        'Checked: npm root -g, NVM_DIR/versions/node/*/lib/node_modules/openclaw/dist, ' +
+        '~/.nvm/current/lib/node_modules/openclaw/dist. ' +
+        'Is openclaw installed globally?',
+    );
   }
 
   return distDir;


### PR DESCRIPTION
On managed instances nvm is only loaded in interactive shells, so npm root -g fails when runner executes patch-tool-order. This adds an nvm path fallback.

## Summary
- Try `npm root -g` first (works when npm is on PATH)
- Fall back to scanning `NVM_DIR` or `~/.nvm/versions/node` for openclaw/dist
- Throw descriptive error if both methods fail
- Added unit tests covering happy path, nvm fallback, and error case

## Test plan
- [x] `npx vitest run` — all 391 tests pass
- [x] `npx eslint .` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)