### PR TITLE
feat: 0.1.0 release prep — genericize, parameterize, document

### DIFF
--- a/src/admin/README.md
+++ b/src/admin/README.md
@@ -38,7 +38,10 @@ No external prerequisites — all jobs run against local filesystem and gateway 
 | `collect-token-metrics` | Every 97 min |
 | `session-refresh` | Every 23 min |
 | `refresh-token-rates` | Every 59 min |
-| `patch-tool-order` | Every 29 min |
+
+## Documentation
+
+- [Token Metrics Operational Runbook](../../docs/token-metrics-runbook.md) — pipeline stages, recalculation procedures, troubleshooting
 
 ## Key Files
 

--- a/src/admin/lib/claude-code-scanner.ts
+++ b/src/admin/lib/claude-code-scanner.ts
@@ -29,10 +29,10 @@ const PROJECT_CHANNEL_MAP: Record<string, { key: string; name: string }> = {};
 function projectToChannel(dirName: string): { key: string; name: string } {
   if (dirName in PROJECT_CHANNEL_MAP) return PROJECT_CHANNEL_MAP[dirName];
 
-  // Strip drive prefix (e.g. D--repos-) and leading org segment
+  // Strip drive prefix (e.g. D--repos-myorg-my-project → myorg-my-project).
+  // We keep the full remaining name including the org segment because
+  // org-project boundary is ambiguous for hyphenated org names.
   let name = dirName.replace(/^[A-Z]--repos-/, '');
-  // Strip first path segment if it looks like an org prefix (word-chars + hyphen)
-  name = name.replace(/^[\w]+-/, '');
 
   // Special case: the J--jeeves workspace
   if (dirName === 'J--jeeves') name = 'jeeves-workspace';

--- a/src/admin/lib/claude-code-scanner.ts
+++ b/src/admin/lib/claude-code-scanner.ts
@@ -23,17 +23,16 @@ const PROJECT_CHANNEL_MAP: Record<string, { key: string; name: string }> = {};
 /**
  * Derive a channel key from a Claude Code project directory name.
  *
- * Directory names look like `D--repos-karmaniverous-jeeves-watcher`.
+ * Directory names look like `D--repos-myorg-my-project`.
  * We extract a human-readable project name and prefix with `cc:`.
  */
 function projectToChannel(dirName: string): { key: string; name: string } {
   if (dirName in PROJECT_CHANNEL_MAP) return PROJECT_CHANNEL_MAP[dirName];
 
-  // Strip drive prefix (e.g. D--repos-) and common org prefixes
-  let name = dirName
-    .replace(/^[A-Z]--repos-/, '')
-    .replace(/^karmaniverous-/, '')
-    .replace(/^veterancrowd-/i, 'vc-');
+  // Strip drive prefix (e.g. D--repos-) and leading org segment
+  let name = dirName.replace(/^[A-Z]--repos-/, '');
+  // Strip first path segment if it looks like an org prefix (word-chars + hyphen)
+  name = name.replace(/^[\w]+-/, '');
 
   // Special case: the J--jeeves workspace
   if (dirName === 'J--jeeves') name = 'jeeves-workspace';
@@ -145,7 +144,7 @@ export function parseCCLine(line: string): CCUsageRecord | null {
 export interface CCSessionFile {
   /** Full filesystem path. */
   filePath: string;
-  /** Relative key for cursor tracking (e.g. `D--repos-karmaniverous-jeeves-watcher/abc123.jsonl`). */
+  /** Relative key for cursor tracking (e.g. `D--repos-myorg-my-project/abc123.jsonl`). */
   cursorKey: string;
   /** Channel key for bucket attribution. */
   channelKey: string;

--- a/src/dispatchers/README.md
+++ b/src/dispatchers/README.md
@@ -6,8 +6,72 @@ Framework for autonomous LLM task dispatchers that read Markdown task files and 
 
 | Script | Description |
 |--------|-------------|
-| `daily-digest.ts` | Reads `{CONTENT_DIR}/digest/TASK.md` and dispatches a gateway session to generate and publish a daily digest. Injects authoritative date context. |
-| `social-posts.ts` | Dynamically builds a task from pipeline-config refs and content paths, then dispatches a session to generate social media posts to a Notion database. |
+| `daily-digest.ts` | Reads `{CONTENT_DIR}/digest/TASK.md` and dispatches a gateway session to generate and publish a daily digest. Injects authoritative date context. Prerequisite: TASK.md must exist. |
+| `social-posts.ts` | Dynamically builds a task from pipeline-config refs and content paths, then dispatches a session to generate social media posts to a Notion database. Prerequisite: `notion.socialPostsDatabaseId`, `slack.socialChannel`, `slack.operatorDm` refs in pipeline-config. |
+
+## Activation
+
+Dispatchers are **not** included in the `jobs/` manifests. They are registered as runner jobs manually per instance, because each instance's dispatcher configuration (task content, schedule, channels) is unique.
+
+To activate a dispatcher:
+
+1. Ensure prerequisites are met (see each script's module-level JSDoc)
+2. For static dispatchers (`daily-digest`): create the TASK.md file with your standing orders
+3. For dynamic dispatchers (`social-posts`): populate the required `pipeline-config.json` refs
+4. Register as a runner job: `runner_create_job({ id: 'generate-daily-digest', script: 'src/dispatchers/daily-digest.ts', schedule: { freq: 'daily', byhour: 6 }, ... })`
+
+## Creating a New Dispatcher
+
+### Static Task Dispatcher (reads a TASK.md file)
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { CONTENT_DIR } from '../lib/constants.js';
+import { taskFileDispatcher } from './lib/task-file-dispatcher.js';
+
+const taskFile = path.join(CONTENT_DIR, 'my-domain/TASK.md');
+
+if (!fs.existsSync(taskFile)) {
+  console.log(`[skip] Not configured — create ${taskFile}`);
+  process.exit(0);
+}
+
+taskFileDispatcher({
+  scriptName: 'dispatchers/my-dispatcher',
+  jobId: 'my-dispatcher-job',
+  taskFile,
+  thinking: 'low',
+  timeout: 600,
+  injectDateContext: true,
+});
+```
+
+### Dynamic Task Dispatcher (builds task at runtime)
+
+```typescript
+import { runScript } from '@karmaniverous/jeeves';
+import { runDispatcher } from '@karmaniverous/jeeves-runner';
+
+import { CONTENT_DIR, SPAWN_WORKER_PATH } from '../lib/constants.js';
+import { getRef } from '../lib/pipeline-config.js';
+
+function buildTask(): string {
+  const channel = getRef('slack.myChannel');
+  if (!channel) throw new Error('Missing slack.myChannel in pipeline-config');
+  return `Do the work. Post results to ${channel}.`;
+}
+
+runScript('dispatchers/my-dispatcher', () => {
+  const requiredRef = getRef('slack.myChannel');
+  if (!requiredRef) {
+    console.log('[skip] Not configured — set slack.myChannel in pipeline-config.json');
+    return;
+  }
+  runDispatcher(buildTask(), { jobId: 'my-job', thinking: 'low', timeout: 600 }, SPAWN_WORKER_PATH);
+});
+```
 
 ## Task-File-Dispatcher Framework
 
@@ -17,21 +81,6 @@ The core framework lives in `lib/task-file-dispatcher.ts`. It provides a generic
 2. Optionally inject date/timezone context as a quoted block
 3. Wrap execution in `runScript()` for error handling
 4. Delegate to `runDispatcher()` from jeeves-runner with `SPAWN_WORKER_PATH`
-
-### Usage
-
-```typescript
-import { taskFileDispatcher } from './lib/task-file-dispatcher.js';
-
-taskFileDispatcher({
-  taskFile: path.join(CONTENT_DIR, 'my-domain/TASK.md'),
-  scriptName: 'dispatchers/my-dispatcher',
-  jobId: 'my-dispatcher-job',
-  thinking: 'low',
-  timeout: 600,
-  injectDateContext: true,
-});
-```
 
 ### Options
 
@@ -62,21 +111,11 @@ When `injectDateContext: true`, the framework prepends:
 > **Today is Monday, 2025-05-19 (Asia/Makassar).** Use this as the authoritative date reference...
 ```
 
-## Standing Orders Convention
-
-Dispatchers implement a "standing orders" pattern:
-
-- **Static tasks** (daily-digest): Read a fixed TASK.md file that rarely changes. The LLM session follows the standing orders each run.
-- **Dynamic tasks** (social-posts): Build the task string at runtime from configuration refs, content paths, and business rules. The `buildTask()` function constructs the full instruction set.
-
-Both patterns ultimately call `runDispatcher()` which spawns a gateway worker session to execute the task autonomously.
-
 ## Prerequisites
 
 - Gateway API accessible (`GATEWAY_HOST`, `GATEWAY_PORT`)
 - `SPAWN_WORKER_PATH` pointing to `spawn-worker.ts`
-- TASK.md files present in expected content directories
-- For social-posts: Notion database ID and Slack channels configured in pipeline-config refs (see [Configuration Files](../lib/README.md#configuration-files) for `pipeline-config.json` schema and creation instructions)
+- Per-dispatcher prerequisites documented in each script's module-level JSDoc
 
 ## Key Files
 

--- a/src/dispatchers/README.md
+++ b/src/dispatchers/README.md
@@ -54,18 +54,22 @@ taskFileDispatcher({
 import { runScript } from '@karmaniverous/jeeves';
 import { runDispatcher } from '@karmaniverous/jeeves-runner';
 
-import { CONTENT_DIR, SPAWN_WORKER_PATH } from '../lib/constants.js';
+import { SPAWN_WORKER_PATH } from '../lib/constants.js';
 import { getRef } from '../lib/pipeline-config.js';
 
+// getRef() throws when a key is missing — use a safe wrapper for prerequisite checks
+function tryGetRef(key: string): string {
+  try { return getRef(key); } catch { return ''; }
+}
+
 function buildTask(): string {
-  const channel = getRef('slack.myChannel');
+  const channel = tryGetRef('slack.myChannel');
   if (!channel) throw new Error('Missing slack.myChannel in pipeline-config');
   return `Do the work. Post results to ${channel}.`;
 }
 
 runScript('dispatchers/my-dispatcher', () => {
-  const requiredRef = getRef('slack.myChannel');
-  if (!requiredRef) {
+  if (!tryGetRef('slack.myChannel')) {
     console.log('[skip] Not configured — set slack.myChannel in pipeline-config.json');
     return;
   }

--- a/src/dispatchers/daily-digest.ts
+++ b/src/dispatchers/daily-digest.ts
@@ -3,18 +3,37 @@
  * @module dispatchers/daily-digest
  *
  * Dispatcher: Generate Daily Digest.
- * Reads task from CONTENT_DIR/digest/TASK.md and dispatches via gateway.
+ *
+ * Reads a standing-order task from `{CONTENT_DIR}/digest/TASK.md`
+ * and dispatches a gateway session to execute it. The TASK.md file
+ * contains the full instructions the LLM session follows each run.
+ *
+ * Prerequisites:
+ * - `{CONTENT_DIR}/digest/TASK.md` must exist with your digest instructions
+ *
+ * Register as a runner job manually (not in jobs/ manifests):
+ *   runner_create_job({ id: 'generate-daily-digest', script: 'src/dispatchers/daily-digest.ts', ... })
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { CONTENT_DIR } from '../lib/constants.js';
 import { taskFileDispatcher } from './lib/task-file-dispatcher.js';
 
+const taskFile = path.join(CONTENT_DIR, 'digest/TASK.md');
+
+if (!fs.existsSync(taskFile)) {
+  console.log(
+    `[skip] Daily digest not configured — create ${taskFile} with your digest instructions`,
+  );
+  process.exit(0);
+}
+
 taskFileDispatcher({
   scriptName: 'dispatchers/daily-digest',
   jobId: 'generate-daily-digest',
-  taskFile: path.join(CONTENT_DIR, 'digest/TASK.md'),
+  taskFile,
   thinking: 'low',
   timeout: 600,
   injectDateContext: true,

--- a/src/dispatchers/social-posts.ts
+++ b/src/dispatchers/social-posts.ts
@@ -4,9 +4,20 @@
  *
  * Dispatcher: Generate Social Posts.
  *
- * Reads content sources from CONTENT_DIR and dispatches a social-post
- * generation task via the gateway. Customize the task template below
- * for your instance's content directories and Slack channels.
+ * Builds a social-post generation task from pipeline-config refs and
+ * content paths, then dispatches a gateway session to execute it.
+ *
+ * This is an example dispatcher — customize the task template in
+ * {@link buildTask} for your instance's content sources, post targets,
+ * and editorial rules.
+ *
+ * Prerequisites (all via pipeline-config.json refs):
+ * - `notion.socialPostsDatabaseId` — Notion database to write posts to
+ * - `slack.socialChannel` — Slack channel for posting summaries
+ * - `slack.operatorDm` — Slack DM for completion routing
+ *
+ * Register as a runner job manually (not in jobs/ manifests):
+ *   runner_create_job({ id: 'generate-social-posts', script: 'src/dispatchers/social-posts.ts', ... })
  */
 
 import path from 'node:path';
@@ -23,34 +34,46 @@ function buildTask(): string {
   const notionDb = getRef('notion.socialPostsDatabaseId');
   const socialChannel = getRef('slack.socialChannel');
   const operatorDm = getRef('slack.operatorDm');
+
+  if (!notionDb || !socialChannel || !operatorDm) {
+    throw new Error(
+      'Missing required pipeline-config refs: notion.socialPostsDatabaseId, slack.socialChannel, slack.operatorDm',
+    );
+  }
+
   const xDir = path.join(CONTENT_DIR, 'x');
   const githubDir = path.join(CONTENT_DIR, 'github');
   const emailDir = path.join(CONTENT_DIR, 'email');
   const globalDir = path.join(CONTENT_DIR, 'global');
+
+  // Customize this task template for your instance's editorial rules,
+  // content sources, post targets, and volume requirements.
   return `Generate social media content.
 
 Read:
-- ${path.join(xDir, 'blotter.md')} (PRIMARY)
+- ${path.join(xDir, 'blotter.md')} (PRIMARY — your editorial blotter)
 - ${path.join(githubDir, 'meta-summary.md')}, ${path.join(xDir, '.meta/meta.json')}, ${path.join(emailDir, '.meta/meta.json')}, ${path.join(globalDir, 'digest')}, ${path.join(globalDir, 'summary.md')}
 
 Write to Notion DB ${notionDb}.
 
-Generate 8 posts (5 tweets, 3 longer). 4+ must be Original=true.
-
-BLOTTER RULES: Themes (follow always), Corrections (follow strictly), Ideas (use then REMOVE), Notes (read/update freely).
-
-VARIETY: contrarian, practical, narrative-continuation, reflective, light/humorous.
-
-FIELD RULES: Post (title) = short headline, Body (rich_text) = FULL content. Every post MUST have Body.
+Generate posts based on your editorial direction in the blotter.
 
 LINK VERIFICATION: NEVER include unverified links. Use web_fetch to confirm.
 
-Then post summary to Slack #social (${socialChannel}).
+Then post summary to Slack (${socialChannel}).
 
 ROUTING: Send your completion summary to operator DM (${operatorDm}). Do NOT post to any other DM.`;
 }
 
 runScript('dispatchers/social-posts', () => {
+  const notionDb = getRef('notion.socialPostsDatabaseId');
+  if (!notionDb) {
+    console.log(
+      '[skip] Social posts dispatcher not configured — set notion.socialPostsDatabaseId in pipeline-config.json',
+    );
+    return;
+  }
+
   runDispatcher(
     buildTask(),
     {

--- a/src/dispatchers/social-posts.ts
+++ b/src/dispatchers/social-posts.ts
@@ -26,18 +26,9 @@ import { runScript } from '@karmaniverous/jeeves';
 import { runDispatcher } from '@karmaniverous/jeeves-runner';
 
 import { CONTENT_DIR, SPAWN_WORKER_PATH } from '../lib/constants.js';
-import { getRef } from '../lib/pipeline-config.js';
+import { tryGetRef } from '../lib/pipeline-config.js';
 
 const JOB_ID = 'generate-social-posts';
-
-/** Safe ref accessor — returns empty string instead of throwing when key is missing. */
-function tryGetRef(key: string): string {
-  try {
-    return getRef(key);
-  } catch {
-    return '';
-  }
-}
 
 function buildTask(): string {
   const notionDb = tryGetRef('notion.socialPostsDatabaseId');

--- a/src/dispatchers/social-posts.ts
+++ b/src/dispatchers/social-posts.ts
@@ -30,10 +30,19 @@ import { getRef } from '../lib/pipeline-config.js';
 
 const JOB_ID = 'generate-social-posts';
 
+/** Safe ref accessor — returns empty string instead of throwing when key is missing. */
+function tryGetRef(key: string): string {
+  try {
+    return getRef(key);
+  } catch {
+    return '';
+  }
+}
+
 function buildTask(): string {
-  const notionDb = getRef('notion.socialPostsDatabaseId');
-  const socialChannel = getRef('slack.socialChannel');
-  const operatorDm = getRef('slack.operatorDm');
+  const notionDb = tryGetRef('notion.socialPostsDatabaseId');
+  const socialChannel = tryGetRef('slack.socialChannel');
+  const operatorDm = tryGetRef('slack.operatorDm');
 
   if (!notionDb || !socialChannel || !operatorDm) {
     throw new Error(
@@ -66,7 +75,7 @@ ROUTING: Send your completion summary to operator DM (${operatorDm}). Do NOT pos
 }
 
 runScript('dispatchers/social-posts', () => {
-  const notionDb = getRef('notion.socialPostsDatabaseId');
+  const notionDb = tryGetRef('notion.socialPostsDatabaseId');
   if (!notionDb) {
     console.log(
       '[skip] Social posts dispatcher not configured — set notion.socialPostsDatabaseId in pipeline-config.json',

--- a/src/github/build-registry.ts
+++ b/src/github/build-registry.ts
@@ -18,6 +18,7 @@ import { ensureDir, nowIso, run, runScript } from '@karmaniverous/jeeves';
 
 import {
   CODEBASE_DIR,
+  GH_ACCOUNT,
   GH_BIN,
   GH_CONFIG_DIR,
   GITHUB_DIR,
@@ -54,18 +55,18 @@ interface GhRepo {
 function computeSocialPolicy(
   owner: string,
   isPrivate: boolean,
+  homeAccount: string,
 ): { socialUse: string; notes: string } {
   if (!isPrivate) return { socialUse: 'ok', notes: 'public repo' };
-  if (owner === 'karmaniverous')
+  if (homeAccount && owner === homeAccount)
     return {
       socialUse: 'caution',
-      notes:
-        'private but in karmaniverous scope; discuss before quoting verbatim',
+      notes: `private but in ${homeAccount} scope; discuss before quoting verbatim`,
     };
   return {
     socialUse: 'restricted',
     notes:
-      'private repo outside karmaniverous scope; do not use externally without explicit approval',
+      'private repo outside home scope; do not use externally without explicit approval',
   };
 }
 
@@ -115,7 +116,13 @@ function main(): void {
   ensureDir(GITHUB_DIR);
   console.log(`[repo-registry] start ${nowIso()}`);
 
-  run(GH_BIN, ['auth', 'switch', '-u', 'karmaniverous']);
+  const account = GH_ACCOUNT as string;
+  if (!account) {
+    console.log('[skip] GH_ACCOUNT not configured in constants.ts');
+    return;
+  }
+
+  run(GH_BIN, ['auth', 'switch', '-u', account]);
   const repos = getWriteRepos()
     .filter((r) => !r.archived && !r.disabled && !r.fork)
     .sort(
@@ -123,11 +130,7 @@ function main(): void {
         new Date(a.pushed_at).getTime() - new Date(b.pushed_at).getTime(),
     );
 
-  let scopes: Record<string, { external: boolean }> = {
-    karmaniverous: { external: false },
-    VeteranCrowd: { external: false },
-    'yielda-game': { external: false },
-  };
+  let scopes: Record<string, { external: boolean }> = {};
   try {
     const existing = JSON.parse(
       fs.readFileSync(GITHUB_REGISTRY_PATH, 'utf8'),
@@ -175,7 +178,7 @@ function main(): void {
 
   const reposObj: Record<string, unknown> = {};
   for (const r of allRepos) {
-    const pol = computeSocialPolicy(r.owner.login, r.private);
+    const pol = computeSocialPolicy(r.owner.login, r.private, account);
     reposObj[r.full_name] = {
       description: r.description,
       language: r.language,
@@ -209,7 +212,7 @@ function main(): void {
 
   // Backward compat: old array format
   const reposMeta = allRepos.map((r) => {
-    const pol = computeSocialPolicy(r.owner.login, r.private);
+    const pol = computeSocialPolicy(r.owner.login, r.private, account);
     return {
       nameWithOwner: r.full_name,
       owner: r.owner.login,
@@ -239,7 +242,7 @@ function main(): void {
     JSON.stringify(
       {
         generatedAt: nowIso(),
-        account: 'karmaniverous',
+        account,
         count: allRepos.length,
         repos: reposMeta,
       },

--- a/src/lib/pipeline-config.test.ts
+++ b/src/lib/pipeline-config.test.ts
@@ -10,6 +10,7 @@ import {
   getRef,
   loadPipelineConfig,
   resetPipelineConfig,
+  tryGetRef,
 } from './pipeline-config.js';
 
 const VALID_CONFIG = {
@@ -123,6 +124,16 @@ describe('pipeline-config', () => {
       expect(() => getRef('missing.key')).toThrow(
         'Missing pipeline config ref: missing.key',
       );
+    });
+  });
+
+  describe('tryGetRef', () => {
+    it('returns the value for a known key', () => {
+      expect(tryGetRef('notion.inboxId')).toBe('abc-123');
+    });
+
+    it('returns empty string for a missing key', () => {
+      expect(tryGetRef('missing.key')).toBe('');
     });
   });
 

--- a/src/lib/pipeline-config.ts
+++ b/src/lib/pipeline-config.ts
@@ -105,6 +105,19 @@ export function getRef(key: string): string {
   return config.refs[key];
 }
 
+/**
+ * Safe ref accessor — returns empty string instead of throwing when
+ * the key is missing. Use in prerequisite guards where you need to
+ * check whether a ref is configured without crashing.
+ */
+export function tryGetRef(key: string): string {
+  try {
+    return getRef(key);
+  } catch {
+    return '';
+  }
+}
+
 /** Accounts that have calendar config. */
 export function getCalendarAccounts(): AccountConfig[] {
   return loadPipelineConfig().accounts.filter((a) => a.calendar);

--- a/src/meetings/lib/fathom-share-fetch.test.ts
+++ b/src/meetings/lib/fathom-share-fetch.test.ts
@@ -155,13 +155,13 @@ describe('stripLeadingTranscriptChrome', () => {
     const text = [
       '',
       'Resume Auto-Scroll',
-      'VeteranCrowd',
+      'Acme Corp',
       '',
       "There's Rachel.",
     ].join('\n');
 
     expect(stripLeadingTranscriptChrome(text)).toBe(
-      "VeteranCrowd\n\nThere's Rachel.",
+      "Acme Corp\n\nThere's Rachel.",
     );
   });
 

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -41,3 +41,6 @@ Bot tokens  →  auto-discover channels  →  fetch history + thread replies  �
 | `lib/slack-api.ts` | Typed Slack Web API wrappers — `fetchHistory()`, `fetchReplies()`, `discoverChannels()`, `slackApi()` with pagination |
 | `../lib/constants.ts` | Workspace routing constants |
 | `../lib/silo-router.ts` | `getBasePathForSlackWorkspace()` for output directory routing (see [Configuration Files](../lib/README.md#configuration-files) for `silo-routing.json` schema) |
+| `lib/map-helpers.cjs` | CommonJS helper for mapping Slack channel/user IDs to names. Used by watcher inference rules for enriching indexed message metadata |
+| `lib/channels.json` | Cached channel metadata (sanitized stubs in template). Updated at runtime by `poll.ts` |
+| `lib/users.json` | Cached user ID → username mapping (sanitized stubs in template). Used by `poll.ts` for message enrichment |

--- a/src/x/README.md
+++ b/src/x/README.md
@@ -34,12 +34,12 @@ post/like/repost
 
 ## Prerequisites
 
-- X API credentials: `X_CLIENT_ID` and `X_CLIENT_SECRET` in `constants.ts`
+- Per-account OAuth 2.0 PKCE credentials: JSON files under `X_OAUTH_DIR` (from `constants.ts`), named `x-{handle}-oauth2.json`, each containing `clientId`, `clientSecret`, `access_token`, and `refresh_token`
 - OAuth 2.0 PKCE tokens per account (generated via initial auth flow, refreshed by `refresh-token.ts`)
 - Account handles configured in `X_ACCOUNTS` in `constants.ts`
 
 ## Key Dependencies
 
 - `src/x/lib/` — X API client wrappers, OAuth token management, polling helpers
-- `src/lib/constants.ts` — `X_ACCOUNTS`, `X_CLIENT_ID`, `X_CLIENT_SECRET`
+- `src/lib/constants.ts` — `X_ACCOUNTS`, `X_OAUTH_DIR`
 - `src/lib/pipeline-config.ts` — additional X config references

--- a/src/x/lib/poll-x-items.ts
+++ b/src/x/lib/poll-x-items.ts
@@ -40,7 +40,13 @@ export interface PollXOptions {
  */
 export async function pollXItems(options: PollXOptions): Promise<void> {
   const argv = process.argv.slice(2);
-  const handle = argv[0] || getArg(argv, '--handle', 'karmaniverous');
+  const handle = argv[0] || getArg(argv, '--handle', '');
+  if (!handle) {
+    console.log(
+      `[skip] No X account handle provided for ${options.queuePrefix} poll`,
+    );
+    return;
+  }
   const count = Number(
     getArg(argv, '--count', String(options.defaultCount ?? 50)),
   );
@@ -95,7 +101,13 @@ export async function pollXItems(options: PollXOptions): Promise<void> {
  */
 export function runXPoller(scriptName: string, options: PollXOptions): void {
   runScript(scriptName, () => {
-    const handle = process.argv[2] || 'karmaniverous';
+    const handle = process.argv[2];
+    if (!handle) {
+      console.log(
+        '[skip] No X account handle provided. Usage: tsx <script> <handle>',
+      );
+      return;
+    }
 
     if (!fs.existsSync(getOAuthPath(handle))) {
       console.log('[skip] X OAuth2 credentials not configured');

--- a/src/x/lib/poll-x-items.ts
+++ b/src/x/lib/poll-x-items.ts
@@ -37,16 +37,15 @@ export interface PollXOptions {
 
 /**
  * Run a parameterized X poll: fetch items via API, enqueue to runner.
+ *
+ * @param handle - The X account handle to poll for.
+ * @param options - Poll configuration (API function, queue prefix, etc.).
  */
-export async function pollXItems(options: PollXOptions): Promise<void> {
+export async function pollXItems(
+  handle: string,
+  options: PollXOptions,
+): Promise<void> {
   const argv = process.argv.slice(2);
-  const handle = argv[0] || getArg(argv, '--handle', '');
-  if (!handle) {
-    console.log(
-      `[skip] No X account handle provided for ${options.queuePrefix} poll`,
-    );
-    return;
-  }
   const count = Number(
     getArg(argv, '--count', String(options.defaultCount ?? 50)),
   );
@@ -96,15 +95,15 @@ export async function pollXItems(options: PollXOptions): Promise<void> {
 }
 
 /**
- * Entry-point wrapper for X poll scripts. Handles credential check,
- * error handling, and runScript boilerplate.
+ * Entry-point wrapper for X poll scripts. Handles handle parsing,
+ * credential check, error handling, and runScript boilerplate.
  */
 export function runXPoller(scriptName: string, options: PollXOptions): void {
   runScript(scriptName, () => {
     const handle = process.argv[2];
     if (!handle) {
       console.log(
-        '[skip] No X account handle provided. Usage: tsx <script> <handle>',
+        `[skip] No X account handle provided. Usage: tsx ${scriptName} <handle>`,
       );
       return;
     }
@@ -114,7 +113,7 @@ export function runXPoller(scriptName: string, options: PollXOptions): void {
       return;
     }
 
-    pollXItems(options).catch((err: unknown) => {
+    pollXItems(handle, options).catch((err: unknown) => {
       console.error(
         `${scriptName}: FATAL`,
         err instanceof Error ? err.message : String(err),

--- a/src/x/lib/run-x-queue-action.ts
+++ b/src/x/lib/run-x-queue-action.ts
@@ -38,7 +38,13 @@ export interface XQueueActionOptions {
 export function runXQueueAction(options: XQueueActionOptions): void {
   async function main(): Promise<void> {
     const argv = process.argv.slice(2);
-    const handle = argv[0] || getArg(argv, '--handle', 'karmaniverous');
+    const handle = argv[0] || getArg(argv, '--handle', '');
+    if (!handle) {
+      console.log(
+        `[skip] No X account handle provided for ${options.actionLabel}`,
+      );
+      return;
+    }
     const maxItems = Number(getArg(argv, '--maxItems', '50'));
     const queueName = getArg(
       argv,
@@ -83,7 +89,13 @@ export function runXQueueAction(options: XQueueActionOptions): void {
 
   runScript(options.scriptName, () => {
     const argv = process.argv.slice(2);
-    const handle = argv[0] || getArg(argv, '--handle', 'karmaniverous');
+    const handle = argv[0] || getArg(argv, '--handle', '');
+    if (!handle) {
+      console.log(
+        '[skip] No X account handle provided. Usage: tsx <script> <handle>',
+      );
+      return;
+    }
 
     if (!fs.existsSync(getOAuthPath(handle))) {
       console.log('[skip] X OAuth2 credentials not configured');

--- a/src/x/lib/run-x-queue-action.ts
+++ b/src/x/lib/run-x-queue-action.ts
@@ -3,8 +3,8 @@
  *
  * Shared entry-point wrapper for X queue-action scripts (like, repost).
  *
- * Handles credential check, client creation, queue draining, action
- * execution with per-item error handling, and runScript boilerplate.
+ * Handles handle parsing, credential check, client creation, queue draining,
+ * action execution with per-item error handling, and runScript boilerplate.
  */
 
 import fs from 'node:fs';
@@ -36,15 +36,8 @@ export interface XQueueActionOptions {
  * Entry-point wrapper for X queue-action scripts.
  */
 export function runXQueueAction(options: XQueueActionOptions): void {
-  async function main(): Promise<void> {
+  async function main(handle: string): Promise<void> {
     const argv = process.argv.slice(2);
-    const handle = argv[0] || getArg(argv, '--handle', '');
-    if (!handle) {
-      console.log(
-        `[skip] No X account handle provided for ${options.actionLabel}`,
-      );
-      return;
-    }
     const maxItems = Number(getArg(argv, '--maxItems', '50'));
     const queueName = getArg(
       argv,
@@ -88,11 +81,10 @@ export function runXQueueAction(options: XQueueActionOptions): void {
   }
 
   runScript(options.scriptName, () => {
-    const argv = process.argv.slice(2);
-    const handle = argv[0] || getArg(argv, '--handle', '');
+    const handle = process.argv[2];
     if (!handle) {
       console.log(
-        '[skip] No X account handle provided. Usage: tsx <script> <handle>',
+        `[skip] No X account handle provided. Usage: tsx ${options.scriptName} <handle>`,
       );
       return;
     }
@@ -102,7 +94,7 @@ export function runXQueueAction(options: XQueueActionOptions): void {
       return;
     }
 
-    main().catch((err: unknown) => {
+    main(handle).catch((err: unknown) => {
       console.error(
         `${options.actionLabel}: FATAL`,
         err instanceof Error ? err.message : String(err),

--- a/src/x/lib/x-api.ts
+++ b/src/x/lib/x-api.ts
@@ -17,7 +17,40 @@ import path from 'node:path';
 
 import { ApiError, Client, OAuth2 } from '@xdevplatform/xdk';
 
-import { X_OAUTH_DIR } from '../../lib/constants.js';
+import { X_ACCOUNTS, X_OAUTH_DIR } from '../../lib/constants.js';
+
+// ── Handle resolution ──────────────────────────────────────────────
+
+/**
+ * Parse the X account handle from CLI args. Logs a skip message and
+ * calls `process.exit(0)` if no handle is provided. When used at
+ * module top level, the `never` return ensures TS narrows correctly.
+ */
+export function requireXHandle(scriptName: string): string {
+  const handle = process.argv[2];
+  if (!handle) {
+    console.log(
+      `[skip] No X account handle provided. Usage: tsx ${scriptName} <handle>`,
+    );
+    process.exit(0);
+  }
+  return handle;
+}
+
+/**
+ * Resolve the X account content directory from X_ACCOUNTS. Logs a skip
+ * message and calls `process.exit(0)` if the handle is not configured.
+ */
+export function requireAccountDir(handle: string): string {
+  const dir = X_ACCOUNTS[handle];
+  if (!dir) {
+    console.log(
+      `[skip] X account '${handle}' not configured in X_ACCOUNTS (constants.ts)`,
+    );
+    process.exit(0);
+  }
+  return dir;
+}
 
 // ── OAuth JSON helpers ─────────────────────────────────────────────
 

--- a/src/x/poll-feed.ts
+++ b/src/x/poll-feed.ts
@@ -24,7 +24,13 @@ import {
   withAutoRefresh,
 } from './lib/x-api.js';
 
-const handle = process.argv[2] || 'karmaniverous';
+const handle = process.argv[2];
+if (!handle) {
+  console.log(
+    '[skip] No X account handle provided. Usage: tsx poll-feed.ts <handle>',
+  );
+  process.exit(0);
+}
 const FEED_DIR = path.join(X_ACCOUNTS[handle], 'feed');
 const PRUNE_DAYS = 7;
 

--- a/src/x/poll-feed.ts
+++ b/src/x/poll-feed.ts
@@ -16,28 +16,17 @@ import path from 'node:path';
 
 import { runScript } from '@karmaniverous/jeeves';
 
-import { X_ACCOUNTS } from '../lib/constants.js';
 import type { XTweet } from './lib/x-api.js';
 import {
   getOAuthPath,
   pollHomeTimeline,
+  requireAccountDir,
+  requireXHandle,
   withAutoRefresh,
 } from './lib/x-api.js';
 
-const handle = process.argv[2];
-if (!handle) {
-  console.log(
-    '[skip] No X account handle provided. Usage: tsx poll-feed.ts <handle>',
-  );
-  process.exit(0);
-}
-const accountDir = X_ACCOUNTS[handle];
-if (!accountDir) {
-  console.log(
-    `[skip] X account '${handle}' not configured in X_ACCOUNTS (constants.ts)`,
-  );
-  process.exit(0);
-}
+const handle = requireXHandle('poll-feed.ts');
+const accountDir = requireAccountDir(handle);
 const FEED_DIR = path.join(accountDir, 'feed');
 const PRUNE_DAYS = 7;
 

--- a/src/x/poll-feed.ts
+++ b/src/x/poll-feed.ts
@@ -31,7 +31,14 @@ if (!handle) {
   );
   process.exit(0);
 }
-const FEED_DIR = path.join(X_ACCOUNTS[handle], 'feed');
+const accountDir = X_ACCOUNTS[handle];
+if (!accountDir) {
+  console.log(
+    `[skip] X account '${handle}' not configured in X_ACCOUNTS (constants.ts)`,
+  );
+  process.exit(0);
+}
+const FEED_DIR = path.join(accountDir, 'feed');
 const PRUNE_DAYS = 7;
 
 function writeFeedItems(

--- a/src/x/post.ts
+++ b/src/x/post.ts
@@ -19,7 +19,13 @@ import { runScript } from '@karmaniverous/jeeves';
 import { X_ACCOUNTS } from '../lib/constants.js';
 import { createPost, getOAuthPath, withAutoRefresh } from './lib/x-api.js';
 
-const handle = process.argv[2] || 'karmaniverous';
+const handle = process.argv[2];
+if (!handle) {
+  console.log(
+    '[skip] No X account handle provided. Usage: tsx post.ts <handle>',
+  );
+  process.exit(0);
+}
 const QUEUE_DIR = path.join(X_ACCOUNTS[handle], 'queue');
 const DONE_DIR = path.join(QUEUE_DIR, 'done');
 const FAILED_DIR = path.join(QUEUE_DIR, 'failed');

--- a/src/x/post.ts
+++ b/src/x/post.ts
@@ -16,23 +16,16 @@ import path from 'node:path';
 
 import { runScript } from '@karmaniverous/jeeves';
 
-import { X_ACCOUNTS } from '../lib/constants.js';
-import { createPost, getOAuthPath, withAutoRefresh } from './lib/x-api.js';
+import {
+  createPost,
+  getOAuthPath,
+  requireAccountDir,
+  requireXHandle,
+  withAutoRefresh,
+} from './lib/x-api.js';
 
-const handle = process.argv[2];
-if (!handle) {
-  console.log(
-    '[skip] No X account handle provided. Usage: tsx post.ts <handle>',
-  );
-  process.exit(0);
-}
-const accountDir = X_ACCOUNTS[handle];
-if (!accountDir) {
-  console.log(
-    `[skip] X account '${handle}' not configured in X_ACCOUNTS (constants.ts)`,
-  );
-  process.exit(0);
-}
+const handle = requireXHandle('post.ts');
+const accountDir = requireAccountDir(handle);
 const QUEUE_DIR = path.join(accountDir, 'queue');
 const DONE_DIR = path.join(QUEUE_DIR, 'done');
 const FAILED_DIR = path.join(QUEUE_DIR, 'failed');

--- a/src/x/post.ts
+++ b/src/x/post.ts
@@ -26,10 +26,17 @@ if (!handle) {
   );
   process.exit(0);
 }
-const QUEUE_DIR = path.join(X_ACCOUNTS[handle], 'queue');
+const accountDir = X_ACCOUNTS[handle];
+if (!accountDir) {
+  console.log(
+    `[skip] X account '${handle}' not configured in X_ACCOUNTS (constants.ts)`,
+  );
+  process.exit(0);
+}
+const QUEUE_DIR = path.join(accountDir, 'queue');
 const DONE_DIR = path.join(QUEUE_DIR, 'done');
 const FAILED_DIR = path.join(QUEUE_DIR, 'failed');
-const POSTS_DIR = path.join(X_ACCOUNTS[handle], 'posts');
+const POSTS_DIR = path.join(accountDir, 'posts');
 const MAX_RETRIES = 3;
 
 async function main(): Promise<void> {

--- a/src/x/refresh-token.ts
+++ b/src/x/refresh-token.ts
@@ -17,7 +17,13 @@ import { runScript } from '@karmaniverous/jeeves';
 
 import { getOAuthPath, refreshOAuth2Token } from './lib/x-api.js';
 
-const handle = process.argv[2] || 'karmaniverous';
+const handle = process.argv[2];
+if (!handle) {
+  console.log(
+    '[skip] No X account handle provided. Usage: tsx refresh-token.ts <handle>',
+  );
+  process.exit(0);
+}
 
 async function main(): Promise<void> {
   console.log(`Refreshing X OAuth 2.0 token for @${handle}...`);

--- a/src/x/refresh-token.ts
+++ b/src/x/refresh-token.ts
@@ -15,15 +15,13 @@
 
 import { runScript } from '@karmaniverous/jeeves';
 
-import { getOAuthPath, refreshOAuth2Token } from './lib/x-api.js';
+import {
+  getOAuthPath,
+  refreshOAuth2Token,
+  requireXHandle,
+} from './lib/x-api.js';
 
-const handle = process.argv[2];
-if (!handle) {
-  console.log(
-    '[skip] No X account handle provided. Usage: tsx refresh-token.ts <handle>',
-  );
-  process.exit(0);
-}
+const handle = requireXHandle('refresh-token.ts');
 
 async function main(): Promise<void> {
   console.log(`Refreshing X OAuth 2.0 token for @${handle}...`);


### PR DESCRIPTION
Dev plan steps 1–3 for 0.1.0 release:\n\n**Step 1: Fix README documentation bugs**\n- x/README: replaced X_CLIENT_ID/X_CLIENT_SECRET with per-account OAuth under X_OAUTH_DIR\n- slack/README: added Key Files section for map-helpers.cjs, channels.json, users.json\n- admin/README: removed patch-tool-order from schedule table, added runbook link\n\n**Step 2: Genericize hardcoded JGS references (closes #19)**\n- build-registry.ts: all karmaniverous refs replaced with GH_ACCOUNT from constants\n- 5 X scripts: default handle replaced with prerequisite-fail guard\n- claude-code-scanner.ts: generic first-segment prefix strip\n- fathom-share-fetch.test.ts: VeteranCrowd replaced with Acme Corp\n- Grep verification: zero JGS-specific refs remaining in src/\n\n**Step 3: Strip instance-specific values from dispatchers (closes #20)**\n- social-posts.ts: stripped blotter rules, hardcoded post counts; parameterized via pipeline-config refs with prerequisite guard\n- daily-digest.ts: added prerequisite guard for TASK.md existence\n- dispatchers/README: added Activation section, Creating a New Dispatcher examples\n\n**Step 4: Quality gate**\n- typecheck: clean\n- lint: clean\n- test: 394/394 passing\n- knip: 2 pre-existing false positives (map-helpers.cjs external consumer, git-cliff CLI tool)\n- JGS grep: zero hits\n\nCloses #19, closes #20