### PR TITLE
feat: add Jira domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Runner job manifests live in `jobs/` (one JSON file per domain). Scripts are org
 | `dispatchers/` | LLM session dispatch framework | [README](src/dispatchers/README.md) |
 | `email/` | Gmail polling, download, triage, classification | [README](src/email/README.md) |
 | `github/` | Repo sync, issue sync, notifications, collaborator management | [README](src/github/README.md) |
+| `jira/` | Jira webhook drain, backfill, field metadata refresh | [README](src/jira/README.md) |
 | `lib/` | Shared infrastructure (constants, dates, email parsing, CLI wrappers) | [README](src/lib/README.md) |
 | `meetings/` | Meeting extraction (Google Meet, Fathom, Notion) | [README](src/meetings/README.md) |
 | `meta/` | Entity lifecycle maintenance | [README](src/meta/README.md) |

--- a/jobs/jira.json
+++ b/jobs/jira.json
@@ -1,0 +1,15 @@
+[
+  {
+    "_comment": "The Jira drain (drain.ts) is NOT a runner job — it is invoked directly by the jeeves-server Event Gateway when a webhook fires. See src/jira/README.md for gateway config and webhook setup.",
+    "id": "jira-refresh-fields",
+    "name": "Jira Refresh Field Metadata",
+    "script": "src/jira/refresh-fields.ts",
+    "schedule": { "freq": "daily", "byhour": 3, "byminute": 0, "timezone": "UTC" },
+    "description": "Refresh Jira custom field metadata (_fields.json) from REST API. Used by the drain script for custom field name translation.",
+    "overlap_policy": "skip",
+    "timeout_seconds": 60,
+    "enabled": true,
+    "domain": "jira",
+    "prerequisite": "Jira API credentials (JIRA_SITE_URL, JIRA_EMAIL, JIRA_API_TOKEN_PATH in constants.ts)"
+  }
+]

--- a/src/jira/README.md
+++ b/src/jira/README.md
@@ -1,0 +1,227 @@
+# jira/
+
+Jira Cloud webhook drain, one-time backfill, and custom field metadata refresh.
+
+## Overview
+
+The Jira domain archives Jira Cloud entities — issues, comments, versions, sprints, and boards — as individual JSON files with reverse-diff change history. Two ingestion paths feed the archive:
+
+- **Webhook drain** (`drain.ts`) — real-time stream from Jira's webhook system via the jeeves-server Event Gateway. Each incoming event is routed by `webhookEvent` type and persisted immediately.
+- **Backfill** (`backfill.ts`) — one-time historical import via the Jira REST API. Run once when bootstrapping a new instance or after data loss. Existing files are skipped.
+
+Custom field names (e.g. `customfield_10001`) are translated to human-readable aliases (e.g. `Sprint`) using a field metadata cache refreshed daily by `refresh-fields.ts`.
+
+## Architecture
+
+```
+Jira Cloud
+    │
+    │  webhook POST
+    ▼
+jeeves-server Event Gateway
+    │  stdin pipe
+    ▼
+src/jira/drain.ts  ──────────────────────────────────────────────────────────┐
+    │  routes by webhookEvent                                                 │
+    ├── jira:issue_created / jira:issue_updated ──► {domainDir}/issue/{key}.json
+    ├── jira:issue_deleted                       ──► delete file
+    ├── comment_created / comment_updated        ──► {domainDir}/comment/{id}.json
+    ├── comment_deleted                          ──► delete file
+    ├── jira:version_*                           ──► {domainDir}/version/{id}.json
+    ├── sprint_*                                 ──► {domainDir}/sprint/{id}.json
+    ├── board_*                                  ──► {domainDir}/board/{id}.json
+    └── (unrecognised)                           ──► {domainDir}/_unmatched/{ts}-{event}.json
+                                                                             │
+src/jira/backfill.ts (one-time, manual)                                      │
+    │  Jira REST API /search                                                  │
+    └──────────────────────────────────────────────────────────────────────  ┘
+          domain dir = {getBasePathForJira()}/jira/
+
+src/jira/refresh-fields.ts (daily runner job)
+    │  Jira REST API /field
+    └──► {domainDir}/_fields.json   (customfield_N → human name)
+```
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `drain.ts` | Webhook drain — reads stdin, routes by event type, persists entity snapshots |
+| `backfill.ts` | One-time historical import via Jira REST API (`--project KEY [--type issue] [--live]`) |
+| `refresh-fields.ts` | Fetch field metadata and write `_fields.json` (daily runner job) |
+
+Supporting modules in `lib/`:
+
+| Module | Description |
+|--------|-------------|
+| `lib/entity-store.ts` | `upsertEntity`, `backfillEntity`, `deleteEntity` — file I/O with diff history |
+| `lib/jira-client.ts` | `jiraGet`, `searchIssues` — typed Jira REST API v3 client |
+
+## Archive Structure
+
+```
+{CONTENT_DIR}/jira/          ← or silo basePath/jira/ in multi-tenant
+  issue/
+    WEB-1.json
+    WEB-2.json
+    ...
+  comment/
+    12345.json
+    ...
+  version/
+    67890.json
+    ...
+  sprint/
+    1001.json
+    ...
+  board/
+    2001.json
+    ...
+  _fields.json                ← custom field name map (written by refresh-fields)
+  _unmatched/                 ← raw payloads for events not yet routed
+    1718800000000-unknown_event.json
+```
+
+### Entity Key Extraction
+
+| Entity Type | Payload Object | Key Field | Example File |
+|-------------|----------------|-----------|--------------|
+| `issue`     | `body.issue`   | `key`     | `issue/WEB-1.json` |
+| `comment`   | `body.comment` | `id`      | `comment/12345.json` |
+| `version`   | `body.version` | `id`      | `version/67890.json` |
+| `sprint`    | `body.sprint`  | `id`      | `sprint/1001.json` |
+| `board`     | `body.board`   | `id`      | `board/2001.json` |
+
+### Entity File Format
+
+Each entity file is a JSON object with the following structure:
+
+```json
+{
+  "entityType": "issue",
+  "entityKey": "WEB-1",
+  "current": { "...": "full Jira payload snapshot" },
+  "history": [
+    {
+      "ts": "2026-01-15T10:00:00.000Z",
+      "patch": [
+        { "op": "replace", "path": "/fields/status/name", "value": "In Progress" }
+      ]
+    }
+  ],
+  "meta": {
+    "firstSeen": "2026-01-10T08:00:00.000Z",
+    "lastWebhook": "2026-01-15T10:00:00.000Z",
+    "lastBackfill": null,
+    "version": 7
+  }
+}
+```
+
+**Reverse-diff model:** `history` entries are JSON patches that transform the **current** snapshot back to the **previous** state. Apply patches in order from newest to oldest to reconstruct any prior state.
+
+## Webhook Setup
+
+1. In Jira Cloud, go to **Settings → System → WebHooks**.
+2. Click **Create a WebHook**.
+3. **URL:** `https://your-jeeves-server.example.com/api/events/jira` (see Event Gateway Config below for the exact path pattern).
+4. **Events to send:** Select all issue events, comment events, and any additional entity types (version, sprint, board) you want to archive.
+5. **JQL filter (optional):** Limit to specific projects, e.g. `project in (WEB, API)`.
+6. Save. Jira immediately starts delivering events.
+
+> **Note:** Jira Cloud webhooks deliver events within seconds. There is no replay mechanism — events missed while the gateway is down will not be redelivered. Run the backfill script after any extended downtime.
+
+## Event Gateway Config
+
+Add this block to your jeeves-server Event Gateway configuration:
+
+```jsonc
+{
+  "eventGateway": {
+    "schemas": [
+      {
+        "pattern": "jira",
+        "cmd": ["tsx", "{SCRIPTS_DIR}/src/jira/drain.ts"],
+        "timeoutMs": 10000
+      }
+    ]
+  }
+}
+```
+
+- `{SCRIPTS_DIR}` — absolute path to the scripts repo checkout (from `SCRIPTS_DIR` in `constants.ts`)
+- `pattern` — must match the path segment used in the webhook URL (e.g. `/api/events/jira`)
+- `timeoutMs` — 10 seconds is ample; drain scripts are fast I/O-only operations
+
+The gateway pipes the raw HTTP request body to the script's stdin and captures stdout/stderr for logging.
+
+## Custom Field Translation
+
+Jira stores custom fields as `customfield_N` keys. The drain script enriches issue payloads with human-readable aliases using a field map stored in `_fields.json`:
+
+```json
+{
+  "customfield_10001": "Sprint",
+  "customfield_10014": "Epic Link",
+  "customfield_10020": "Story point estimate"
+}
+```
+
+The map is updated daily by `refresh-fields.ts` (scheduled runner job). After an alias is added to `_fields.json`, all new webhook events will include both the raw key and the alias:
+
+```json
+{
+  "customfield_10001": { "id": "42", "name": "Sprint 7" },
+  "Sprint":            { "id": "42", "name": "Sprint 7" }
+}
+```
+
+## Backfill
+
+Run the backfill once after setting up the webhook to populate historical data:
+
+```bash
+# Dry run (preview — no writes)
+tsx src/jira/backfill.ts --project WEB
+
+# Live run (actual writes)
+tsx src/jira/backfill.ts --project WEB --live
+
+# Backfill a different entity type (future)
+tsx src/jira/backfill.ts --project WEB --type issue --live
+```
+
+**CLI arguments:**
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--project KEY` | _(required)_ | Jira project key (e.g. `WEB`) |
+| `--type TYPE` | `issue` | Entity type to backfill |
+| `--live` | false | Perform actual writes (dry-run by default) |
+
+**Rate limiting:** 200 ms pause between API requests to avoid hitting Jira Cloud rate limits.
+
+**Skip behaviour:** The backfill skips any entity file that already exists on disk. This ensures webhook-delivered data (which is fresher) is never overwritten by the backfill.
+
+## Prerequisites
+
+| Prerequisite | Where to configure |
+|---|---|
+| Jira Cloud account with API token | [id.atlassian.com → API tokens](https://id.atlassian.com/manage-profile/security/api-tokens) |
+| `JIRA_SITE_URL` | `src/lib/constants.ts` — e.g. `'https://mysite.atlassian.net'` |
+| `JIRA_EMAIL` | `src/lib/constants.ts` — Atlassian account email |
+| `JIRA_API_TOKEN_PATH` | `src/lib/constants.ts` — path to API token file |
+| Jira webhook configured to POST to jeeves-server | Jira Cloud → Settings → System → WebHooks |
+| jeeves-server Event Gateway configured with `jira` schema | `jeeves-server` config (see Event Gateway Config above) |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `drain.ts` | Webhook drain entry point — stdin pipe from Event Gateway |
+| `backfill.ts` | One-time historical backfill via REST API |
+| `refresh-fields.ts` | Daily custom field metadata refresh |
+| `lib/entity-store.ts` | File I/O helpers with reverse-diff history |
+| `lib/jira-client.ts` | Typed Jira REST API v3 client (fetch, paginate) |
+| `../../jobs/jira.json` | Runner job manifest (refresh-fields schedule) |
+| `../../src/lib/constants.ts` | Jira constants (`JIRA_SITE_URL`, `JIRA_EMAIL`, etc.) |

--- a/src/jira/backfill.ts
+++ b/src/jira/backfill.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env tsx
+/**
+ * @module backfill
+ *
+ * One-time Jira backfill — populates the issue (and optionally other entity
+ * type) archive from the full Jira project backlog via the REST API.
+ *
+ * Run manually when setting up a new instance or after a data loss event.
+ * Existing entity files are skipped (webhook data is fresher). Dry-run
+ * mode is the default; pass `--live` for actual writes.
+ *
+ * Usage:
+ *   tsx src/jira/backfill.ts --project WEB [--type issue] [--live]
+ *
+ * CLI arguments:
+ *   --project <key>  Jira project key, e.g. WEB (required)
+ *   --type <type>    Entity type to backfill (default: issue)
+ *   --live           Perform actual writes (default: dry-run)
+ */
+
+import path from 'node:path';
+
+import { getArg, nowIso, runScript } from '@karmaniverous/jeeves';
+
+import {
+  JIRA_API_TOKEN_PATH,
+  JIRA_EMAIL,
+  JIRA_SITE_URL,
+} from '../lib/constants.js';
+import { getBasePathForJira } from '../lib/silo-router.js';
+import { backfillEntity } from './lib/entity-store.js';
+import {
+  makeAuthHeader,
+  readApiToken,
+  searchIssues,
+} from './lib/jira-client.js';
+
+const DOMAIN_DIR = path.join(getBasePathForJira(), 'jira');
+const RATE_LIMIT_MS = 200;
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function backfillIssues(
+  projectKey: string,
+  authHeader: string,
+  now: string,
+  live: boolean,
+): Promise<{ created: number; skipped: number; failed: number }> {
+  const jql = `project = ${projectKey} ORDER BY created ASC`;
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for await (const issue of searchIssues(
+    JIRA_SITE_URL,
+    authHeader,
+    jql,
+    '*all',
+    undefined,
+    50,
+  )) {
+    try {
+      const current: Record<string, unknown> = {
+        id: issue.id,
+        key: issue.key,
+        fields: issue.fields,
+      };
+
+      if (live) {
+        const written = backfillEntity(
+          DOMAIN_DIR,
+          'issue',
+          issue.key,
+          current,
+          now,
+        );
+        if (written) {
+          created++;
+          console.log(`[backfill] created ${issue.key}`);
+        } else {
+          skipped++;
+          console.log(`[backfill] skip   ${issue.key} (exists)`);
+        }
+      } else {
+        console.log(`[backfill] dry-run ${issue.key}`);
+        skipped++;
+      }
+    } catch (e) {
+      failed++;
+      console.error(
+        `[backfill] error ${issue.key}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+
+    await sleepMs(RATE_LIMIT_MS);
+  }
+
+  return { created, skipped, failed };
+}
+
+async function backfillMain(): Promise<void> {
+  if (!JIRA_SITE_URL || !JIRA_EMAIL || !JIRA_API_TOKEN_PATH) {
+    console.log('[skip] Jira API credentials not configured');
+    return;
+  }
+
+  const argv = process.argv.slice(2);
+  const project = getArg(argv, '--project', '');
+  const entityType = getArg(argv, '--type', 'issue');
+  const live = hasFlag(argv, '--live');
+
+  if (!project) {
+    console.error('[error] --project <key> is required');
+    process.exit(1);
+  }
+
+  if (entityType !== 'issue') {
+    console.error(
+      `[error] --type "${entityType}" is not yet supported (only "issue")`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[backfill] project=${project} type=${entityType} live=${String(live)}`,
+  );
+  if (!live)
+    console.log('[backfill] DRY-RUN mode — pass --live for actual writes');
+
+  const apiToken = readApiToken(JIRA_API_TOKEN_PATH);
+  const authHeader = makeAuthHeader(JIRA_EMAIL, apiToken);
+  const now = nowIso();
+
+  const { created, skipped, failed } = await backfillIssues(
+    project,
+    authHeader,
+    now,
+    live,
+  );
+
+  console.log(
+    `[backfill] done — created=${String(created)} skipped=${String(skipped)} failed=${String(failed)}`,
+  );
+
+  if (failed > 0) process.exit(1);
+}
+
+runScript('jira/backfill', () => {
+  backfillMain().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+});

--- a/src/jira/drain.ts
+++ b/src/jira/drain.ts
@@ -1,0 +1,255 @@
+#!/usr/bin/env tsx
+/**
+ * @module drain
+ *
+ * Jira webhook drain — receives Jira webhook payloads from the
+ * jeeves-server Event Gateway via stdin, routes by `webhookEvent`, and
+ * persists entity snapshots with reverse-diff history.
+ *
+ * Invoked by jeeves-server's Event Gateway, not by jeeves-runner.
+ * See README.md for gateway config and webhook setup instructions.
+ *
+ * Supported events:
+ *   jira:issue_created, jira:issue_updated, jira:issue_deleted
+ *   comment_created, comment_updated, comment_deleted
+ *   jira:version_created, jira:version_updated, jira:version_deleted
+ *   sprint_created, sprint_updated, sprint_deleted
+ *   board_created, board_updated, board_deleted
+ *
+ * Unrecognised events are written to `{domainDir}/_unmatched/`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { nowIso, runScript } from '@karmaniverous/jeeves';
+
+import { JIRA_FIELDS_FILENAME, JIRA_MAX_HISTORY } from '../lib/constants.js';
+import { getBasePathForJira } from '../lib/silo-router.js';
+import { deleteEntity, upsertEntity } from './lib/entity-store.js';
+
+const DOMAIN_DIR = path.join(getBasePathForJira(), 'jira');
+
+// ---------------------------------------------------------------------------
+// Custom field translation helpers
+// ---------------------------------------------------------------------------
+
+type FieldMap = Record<string, string>;
+
+function loadFieldMap(): FieldMap {
+  const fieldsPath = path.join(DOMAIN_DIR, JIRA_FIELDS_FILENAME);
+  if (!fs.existsSync(fieldsPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(fieldsPath, 'utf8')) as FieldMap;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Add human-readable aliases for every `customfield_*` key present in
+ * `fields`. The alias key is the mapped name from _fields.json; the
+ * original key is preserved.
+ */
+function translateCustomFields(
+  fields: Record<string, unknown>,
+  fieldMap: FieldMap,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...fields };
+  for (const [k, v] of Object.entries(fields)) {
+    if (k.startsWith('customfield_') && fieldMap[k]) {
+      out[fieldMap[k]] = v;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Unmatched event sink
+// ---------------------------------------------------------------------------
+
+function writeUnmatched(event: string, body: unknown): void {
+  const dir = path.join(DOMAIN_DIR, '_unmatched');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${String(Date.now())}-${event}.json`),
+    JSON.stringify(body, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+type DrainResult =
+  | {
+      event: string;
+      action: 'upsert';
+      type: string;
+      key: string | number;
+      path: string;
+    }
+  | {
+      event: string;
+      action: 'delete';
+      type: string;
+      key: string | number;
+      deleted: boolean;
+    }
+  | { event: string; action: 'unmatched' };
+
+// ---------------------------------------------------------------------------
+// Generic entity routing helper
+// ---------------------------------------------------------------------------
+
+function routeUpsertDelete(
+  event: string,
+  obj: Record<string, unknown> | undefined,
+  entityType: string,
+  idKey: 'id' | 'key',
+  now: string,
+): DrainResult {
+  const id = obj?.[idKey] as string | number | undefined;
+  if (id === undefined || id === '') {
+    console.error(`No ${entityType} ${idKey} in payload`);
+    process.exit(1);
+  }
+  if (event.includes('deleted')) {
+    const deleted = deleteEntity(DOMAIN_DIR, entityType, id);
+    return { event, action: 'delete', type: entityType, key: id, deleted };
+  }
+  const p = upsertEntity(
+    DOMAIN_DIR,
+    entityType,
+    id,
+    obj as Record<string, unknown>,
+    now,
+    JIRA_MAX_HISTORY,
+  );
+  return { event, action: 'upsert', type: entityType, key: id, path: p };
+}
+
+// ---------------------------------------------------------------------------
+// Main drain
+// ---------------------------------------------------------------------------
+
+async function drainMain(): Promise<void> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+
+  const event = body.webhookEvent as string | undefined;
+  if (!event) {
+    console.error('No webhookEvent in payload');
+    process.exit(1);
+  }
+
+  const now = nowIso();
+  const fieldMap = loadFieldMap();
+  let result: DrainResult;
+
+  if (event === 'jira:issue_created' || event === 'jira:issue_updated') {
+    const issue = body.issue as Record<string, unknown> | undefined;
+    const key = issue?.key as string | undefined;
+    if (!key) {
+      console.error('No issue key');
+      process.exit(1);
+    }
+    // Translate custom fields in the `fields` sub-object
+    const rawFields = issue?.fields as Record<string, unknown> | undefined;
+    const current: Record<string, unknown> = {
+      ...issue,
+      fields: rawFields
+        ? translateCustomFields(rawFields, fieldMap)
+        : rawFields,
+    };
+    const p = upsertEntity(
+      DOMAIN_DIR,
+      'issue',
+      key,
+      current,
+      now,
+      JIRA_MAX_HISTORY,
+    );
+    result = { event, action: 'upsert', type: 'issue', key, path: p };
+  } else if (event === 'jira:issue_deleted') {
+    const issue = body.issue as Record<string, unknown> | undefined;
+    const key = issue?.key as string | undefined;
+    if (!key) {
+      console.error('No issue key');
+      process.exit(1);
+    }
+    const deleted = deleteEntity(DOMAIN_DIR, 'issue', key);
+    result = { event, action: 'delete', type: 'issue', key, deleted };
+  } else if (event === 'comment_created' || event === 'comment_updated') {
+    const comment = body.comment as Record<string, unknown> | undefined;
+    const id = comment?.id as string | number | undefined;
+    if (id === undefined || id === '') {
+      console.error('No comment id');
+      process.exit(1);
+    }
+    const current: Record<string, unknown> = { ...comment };
+    const issueKey = (body.issue as Record<string, unknown> | undefined)?.key;
+    if (issueKey) current._issueKey = issueKey;
+    const p = upsertEntity(
+      DOMAIN_DIR,
+      'comment',
+      id,
+      current,
+      now,
+      JIRA_MAX_HISTORY,
+    );
+    result = { event, action: 'upsert', type: 'comment', key: id, path: p };
+  } else if (event === 'comment_deleted') {
+    const comment = body.comment as Record<string, unknown> | undefined;
+    const id = comment?.id as string | number | undefined;
+    if (id === undefined || id === '') {
+      console.error('No comment id');
+      process.exit(1);
+    }
+    const deleted = deleteEntity(DOMAIN_DIR, 'comment', id);
+    result = { event, action: 'delete', type: 'comment', key: id, deleted };
+  } else if (event.startsWith('jira:version_')) {
+    result = routeUpsertDelete(
+      event,
+      body.version as Record<string, unknown> | undefined,
+      'version',
+      'id',
+      now,
+    );
+  } else if (event.startsWith('sprint_')) {
+    result = routeUpsertDelete(
+      event,
+      body.sprint as Record<string, unknown> | undefined,
+      'sprint',
+      'id',
+      now,
+    );
+  } else if (event.startsWith('board_')) {
+    result = routeUpsertDelete(
+      event,
+      body.board as Record<string, unknown> | undefined,
+      'board',
+      'id',
+      now,
+    );
+  } else {
+    writeUnmatched(event, body);
+    result = { event, action: 'unmatched' };
+  }
+
+  console.log(JSON.stringify(result));
+}
+
+runScript('jira/drain', () => {
+  drainMain().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+});

--- a/src/jira/lib/entity-store.ts
+++ b/src/jira/lib/entity-store.ts
@@ -1,0 +1,178 @@
+/**
+ * @module entity-store
+ *
+ * Entity persistence helpers for the Jira domain — upsert and delete
+ * entity files with reverse-diff history using fast-json-patch.
+ *
+ * Used by drain.ts (webhook path) and backfill.ts (REST API path).
+ * Callers supply the domain directory, entity type, key, and current
+ * snapshot; this module handles file I/O and history management.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import jsonpatch from 'fast-json-patch';
+
+const compare = jsonpatch.compare.bind(jsonpatch);
+
+export interface HistoryEntry {
+  ts: string;
+  patch: unknown[];
+}
+
+export interface EntityMeta {
+  firstSeen: string;
+  lastWebhook: string;
+  lastBackfill: string | null;
+  version: number;
+}
+
+export interface EntityFile {
+  entityType: string;
+  entityKey: string;
+  current: Record<string, unknown>;
+  history: HistoryEntry[];
+  meta: EntityMeta;
+}
+
+/** Shape of entity files read from disk — all fields optional to handle partial/corrupt files. */
+interface StoredEntity {
+  current?: Record<string, unknown>;
+  history?: HistoryEntry[];
+  meta?: {
+    firstSeen?: string;
+    lastWebhook?: string;
+    lastBackfill?: string | null;
+    version?: number;
+  };
+}
+
+/**
+ * Upsert an entity file with reverse-diff history.
+ *
+ * If the file already exists, computes a reverse patch from the new
+ * snapshot back to the old one and appends it to history. History is
+ * capped at `maxHistory` entries (oldest dropped first).
+ *
+ * @returns Absolute path to the written file.
+ */
+export function upsertEntity(
+  domainDir: string,
+  type: string,
+  key: string | number,
+  current: Record<string, unknown>,
+  now: string,
+  maxHistory: number,
+): string {
+  const dir = path.join(domainDir, type);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${String(key)}.json`);
+
+  let entity: EntityFile | null = null;
+
+  if (fs.existsSync(filePath)) {
+    try {
+      const stored = JSON.parse(
+        fs.readFileSync(filePath, 'utf8'),
+      ) as StoredEntity;
+      if (stored.current) {
+        const reversePatch = compare(current, stored.current);
+        const history = stored.history ?? [];
+        if (reversePatch.length > 0) {
+          history.push({
+            ts: stored.meta?.lastWebhook ?? now,
+            patch: reversePatch,
+          });
+          if (history.length > maxHistory) {
+            history.splice(0, history.length - maxHistory);
+          }
+        }
+        entity = {
+          entityType: type,
+          entityKey: String(key),
+          current,
+          history,
+          meta: {
+            firstSeen: stored.meta?.firstSeen ?? now,
+            lastWebhook: now,
+            lastBackfill: stored.meta?.lastBackfill ?? null,
+            version: (stored.meta?.version ?? 0) + 1,
+          },
+        };
+      }
+    } catch {
+      entity = null;
+    }
+  }
+
+  if (!entity) {
+    entity = {
+      entityType: type,
+      entityKey: String(key),
+      current,
+      history: [],
+      meta: {
+        firstSeen: now,
+        lastWebhook: now,
+        lastBackfill: null,
+        version: 1,
+      },
+    };
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(entity, null, 2) + '\n', 'utf8');
+  return filePath;
+}
+
+/**
+ * Write a backfill entity file (does not overwrite existing files).
+ *
+ * @returns The file path if written, null if skipped (already exists).
+ */
+export function backfillEntity(
+  domainDir: string,
+  type: string,
+  key: string | number,
+  current: Record<string, unknown>,
+  now: string,
+): string | null {
+  const dir = path.join(domainDir, type);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${String(key)}.json`);
+  if (fs.existsSync(filePath)) return null;
+
+  const entity: EntityFile = {
+    entityType: type,
+    entityKey: String(key),
+    current,
+    history: [],
+    meta: {
+      firstSeen: now,
+      lastWebhook: now,
+      lastBackfill: now,
+      version: 1,
+    },
+  };
+
+  fs.writeFileSync(filePath, JSON.stringify(entity, null, 2) + '\n', 'utf8');
+  return filePath;
+}
+
+/**
+ * Delete an entity file.
+ *
+ * @returns true if the file existed and was deleted, false otherwise.
+ */
+export function deleteEntity(
+  domainDir: string,
+  type: string,
+  key: string | number,
+): boolean {
+  const filePath = path.join(domainDir, type, `${String(key)}.json`);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}

--- a/src/jira/lib/jira-client.ts
+++ b/src/jira/lib/jira-client.ts
@@ -1,0 +1,142 @@
+/**
+ * @module jira-client
+ *
+ * Minimal Jira Cloud REST API v3 client for jeeves-scripts.
+ *
+ * Handles basic-auth construction and typed GET requests. All API calls
+ * are unauthenticated with HTTP basic auth (email + API token). Node's
+ * built-in fetch (v18+) is used — no extra dependencies.
+ */
+
+import fs from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface JiraField {
+  id: string;
+  name: string;
+  custom: boolean;
+  schema?: { type: string; custom?: string };
+}
+
+export interface JiraSearchResult {
+  total: number;
+  startAt: number;
+  maxResults: number;
+  issues: JiraIssue[];
+}
+
+export interface JiraIssue {
+  id: string;
+  key: string;
+  fields: Record<string, unknown>;
+  changelog?: { histories: JiraChangelogHistory[] };
+}
+
+export interface JiraChangelogHistory {
+  id: string;
+  author: { displayName: string; emailAddress?: string };
+  created: string;
+  items: Array<{
+    field: string;
+    fieldtype?: string;
+    fromString?: string;
+    toString?: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+/** Read an API token from a file, trimming trailing whitespace. */
+export function readApiToken(tokenPath: string): string {
+  return fs.readFileSync(tokenPath, 'utf8').trim();
+}
+
+/** Build an HTTP Basic Authorization header value. */
+export function makeAuthHeader(email: string, apiToken: string): string {
+  return `Basic ${Buffer.from(`${email}:${apiToken}`).toString('base64')}`;
+}
+
+// ---------------------------------------------------------------------------
+// API request helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform a GET request against the Jira Cloud REST API v3.
+ *
+ * @param siteUrl    e.g. `https://mysite.atlassian.net`
+ * @param authHeader HTTP Basic auth header (from `makeAuthHeader`)
+ * @param apiPath    Path relative to `/rest/api/3/` (e.g. `field`)
+ * @param params     Optional query string parameters
+ */
+export async function jiraGet<T>(
+  siteUrl: string,
+  authHeader: string,
+  apiPath: string,
+  params?: Record<string, string>,
+): Promise<T> {
+  const url = new URL(`${siteUrl}/rest/api/3/${apiPath}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: authHeader, Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Jira API ${String(res.status)} ${apiPath}: ${body}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Paginate a Jira JQL search, yielding issues in batches.
+ *
+ * @param siteUrl    Jira site base URL
+ * @param authHeader HTTP Basic auth header
+ * @param jql        JQL query string
+ * @param fields     Comma-separated field list (pass `'*all'` for everything)
+ * @param expand     Optional comma-separated expand list (e.g. `'changelog'`)
+ * @param maxResults Page size (default 50, max 100 for most Jira instances)
+ */
+export async function* searchIssues(
+  siteUrl: string,
+  authHeader: string,
+  jql: string,
+  fields = '*all',
+  expand?: string,
+  maxResults = 50,
+): AsyncGenerator<JiraIssue> {
+  let startAt = 0;
+  let fetched = 0;
+  let total = Infinity;
+
+  while (fetched < total) {
+    const params: Record<string, string> = {
+      jql,
+      fields,
+      startAt: String(startAt),
+      maxResults: String(maxResults),
+    };
+    if (expand) params.expand = expand;
+
+    const result = await jiraGet<JiraSearchResult>(
+      siteUrl,
+      authHeader,
+      'search',
+      params,
+    );
+
+    total = result.total;
+    for (const issue of result.issues) {
+      yield issue;
+      fetched++;
+    }
+    startAt += result.issues.length;
+    if (result.issues.length === 0) break;
+  }
+}

--- a/src/jira/refresh-fields.ts
+++ b/src/jira/refresh-fields.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env tsx
+/**
+ * @module refresh-fields
+ *
+ * Fetch Jira custom field metadata from `/rest/api/3/field` and write
+ * `_fields.json` to the Jira domain directory.
+ *
+ * The field map (customfield_N → human-readable name) is used by the
+ * drain script to add human-readable aliases alongside raw customfield
+ * keys in persisted issue snapshots.
+ *
+ * Scheduled via `jobs/jira.json` (daily at 03:00 UTC). Can also be
+ * run manually: `tsx src/jira/refresh-fields.ts`
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { nowIso, runScript } from '@karmaniverous/jeeves';
+
+import {
+  JIRA_API_TOKEN_PATH,
+  JIRA_EMAIL,
+  JIRA_FIELDS_FILENAME,
+  JIRA_SITE_URL,
+} from '../lib/constants.js';
+import { getBasePathForJira } from '../lib/silo-router.js';
+import type { JiraField } from './lib/jira-client.js';
+import { jiraGet, makeAuthHeader, readApiToken } from './lib/jira-client.js';
+
+const DOMAIN_DIR = path.join(getBasePathForJira(), 'jira');
+
+async function refreshFieldsMain(): Promise<void> {
+  if (!JIRA_SITE_URL || !JIRA_EMAIL || !JIRA_API_TOKEN_PATH) {
+    console.log('[skip] Jira API credentials not configured');
+    return;
+  }
+
+  const apiToken = readApiToken(JIRA_API_TOKEN_PATH);
+  const authHeader = makeAuthHeader(JIRA_EMAIL, apiToken);
+
+  console.log(`[refresh-fields] fetching field metadata from ${JIRA_SITE_URL}`);
+
+  const fields = await jiraGet<JiraField[]>(JIRA_SITE_URL, authHeader, 'field');
+
+  // Build a map of customfield_N → human-readable name (custom fields only)
+  const fieldMap: Record<string, string> = {};
+  for (const field of fields) {
+    if (field.custom && field.id.startsWith('customfield_')) {
+      fieldMap[field.id] = field.name;
+    }
+  }
+
+  fs.mkdirSync(DOMAIN_DIR, { recursive: true });
+  const outputPath = path.join(DOMAIN_DIR, JIRA_FIELDS_FILENAME);
+  fs.writeFileSync(
+    outputPath,
+    JSON.stringify(fieldMap, null, 2) + '\n',
+    'utf8',
+  );
+
+  console.log(
+    `[refresh-fields] wrote ${String(Object.keys(fieldMap).length)} custom fields to ${outputPath} at ${nowIso()}`,
+  );
+}
+
+runScript('jira/refresh-fields', () => {
+  refreshFieldsMain().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -204,6 +204,45 @@ export const X_OAUTH_DIR = path.join(CREDENTIALS_DIR, 'oauth');
  */
 export const X_ACCOUNTS: Record<string, string> = {};
 
+// ========== Jira [OPTIONAL] ==========
+
+/**
+ * Base URL of the Jira Cloud site.
+ * e.g. `'https://mysite.atlassian.net'`
+ */
+export const JIRA_SITE_URL: string = '';
+
+/**
+ * Atlassian account email used for Jira API basic auth.
+ * e.g. `'jason@example.com'`
+ */
+export const JIRA_EMAIL: string = '';
+
+/**
+ * Path to a file containing the Jira API token (plain text, one line).
+ * Generate at https://id.atlassian.com/manage-profile/security/api-tokens
+ */
+export const JIRA_API_TOKEN_PATH: string = '';
+
+/**
+ * Filename for the Jira custom field metadata cache written by
+ * refresh-fields.ts. Lives at the root of the Jira domain directory.
+ */
+export const JIRA_FIELDS_FILENAME = '_fields.json';
+
+/**
+ * Maximum number of history entries to retain per entity file.
+ * Older entries are dropped when the cap is reached.
+ */
+export const JIRA_MAX_HISTORY = 50;
+
+/**
+ * Root directory for Jira domain output. Used by the refresh-fields
+ * and backfill scripts on single-tenant instances; multi-tenant paths
+ * are resolved at runtime via `getBasePathForJira()` in silo-router.ts.
+ */
+export const JIRA_DIR = path.join(CONTENT_DIR, 'jira');
+
 // ========== Entity Pipeline [OPTIONAL] ==========
 
 /**
@@ -230,6 +269,11 @@ export const ENTITY_TYPES: EntityTypeConfig[] = [
     subdir: 'meetings',
     rejectionKeys: ['nonmeeting', 'non_meeting'],
     maxAgeDays: 7,
+  },
+  {
+    subdir: 'jira/issue',
+    rejectionKeys: [],
+    maxAgeDays: null,
   },
 ];
 


### PR DESCRIPTION
Add Jira domain to the scripts template:

- **drain.ts** — webhook drain (stdin from Event Gateway), routes by webhookEvent, persists entity snapshots with reverse-diff history via fast-json-patch
- **backfill.ts** — one-time historical import via Jira REST API (`--project KEY [--type issue] [--live]`)
- **refresh-fields.ts** — daily runner job to refresh custom field metadata (`_fields.json`)
- **lib/entity-store.ts** — shared upsert/delete/backfill helpers
- **lib/jira-client.ts** — typed Jira REST API v3 client
- **README.md** — architecture, archive structure, webhook setup, Event Gateway config, backfill usage, prerequisites
- **jobs/jira.json** — runner job manifest
- **constants.ts** — Jira constants + ENTITY_TYPES entry

All quality gates pass (typecheck, lint, test, knip).
